### PR TITLE
`Renovate`: Add minimum age of 7 days for non-security Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,17 @@
   "extends": ["config:recommended"],
   "prConcurrentLimit": 3,
   "rangeStrategy": "bump",
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "description": "Group all non-major updates together",
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies"
+    },
+    {
+      "description": "No minimum age for security updates",
+      "matchCategories": ["security"],
+      "minimumReleaseAge": "0 days"
     }
   ]
 }


### PR DESCRIPTION
## ✨ What is the change?

Added a `minimumReleaseAge` of 7 days to the Renovate configuration so that non-security dependency updates are only proposed after the new version has been available for at least 7 days.

## 📌 Reason for the change / Link to issue

Closes #1665

Waiting 7 days before applying non-security updates reduces the risk of picking up packages that are quickly yanked or patched after release (the "dependency left-pad" problem). Security updates bypass this delay and are still applied immediately.

## 🧪 How to Test

1. Review `renovate.json` — `"minimumReleaseAge": "7 days"` is set at the top level.
2. Confirm a `packageRules` entry overrides this to `"0 days"` for `matchCategories: ["security"]`.
3. Trigger a Renovate dry-run and verify non-security PRs are only opened for packages released ≥ 7 days ago.

## 🖼️ Screenshots (if UI changes are included)

N/A — config-only change.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)