### PR TITLE
`Assessment`: remove extra evaluation form padding and fix background color

### DIFF
--- a/clients/assessment_component/src/assessment/pages/EvaluationPages/components/CategoryEvaluation.tsx
+++ b/clients/assessment_component/src/assessment/pages/EvaluationPages/components/CategoryEvaluation.tsx
@@ -47,7 +47,7 @@ export const CategoryEvaluation = ({
       </div>
 
       {isExpanded && (
-        <div id={`content-${category.id}`} className='pt-4 pb-2 space-y-4 mt-2'>
+        <div id={`content-${category.id}`} className='space-y-4'>
           {category.competencies.length === 0 ? (
             <p className='text-sm text-muted-foreground italic'>
               No competencies available in this category.

--- a/clients/assessment_component/src/assessment/pages/EvaluationPages/components/EvaluationForm/EvaluationForm.tsx
+++ b/clients/assessment_component/src/assessment/pages/EvaluationPages/components/EvaluationForm/EvaluationForm.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { AlertCircle } from 'lucide-react'
 
-import { Form, cn } from '@tumaet/prompt-ui-components'
+import { Form } from '@tumaet/prompt-ui-components'
 
 import { AssessmentType } from '../../../../interfaces/assessmentType'
 import { Competency } from '../../../../interfaces/competency'
@@ -100,12 +100,7 @@ export const EvaluationForm = ({
 
   return (
     <Form {...form}>
-      <div
-        className={cn(
-          'space-y-4 p-4 border rounded-md relative',
-          completed && 'bg-gray-700 border-gray-700',
-        )}
-      >
+      <div className='space-y-4 p-4 border rounded-md relative'>
         <CompetencyHeader
           competency={competency}
           competencyScore={evaluation}


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Removes extra spacing and the completed-state dark background from the assessment evaluation form so competency selector content aligns consistently when categories are expanded.

## 📌 Reason for the change / Link to issue

Fixes the visual spacing bug tracked by branch `1694-fix-visual-bug-in-evaluation-competency-selector`.

## 🧪 How to Test

1. Open the assessment component and navigate to an evaluation page with competency categories.
2. Expand a category and inspect the competency selector spacing.
3. Mark a competency evaluation as completed and confirm the form keeps the normal border/card spacing without the dark gray background.

Local validation attempted:

- `yarn workspace assessment_component typecheck && yarn workspace assessment_component lint` from `clients/` failed before checking code because `tsc` is not available in the local dependency setup (`command not found: tsc`).

## 🖼️ Screenshots (if UI changes are included)

Before: 
<img width="1160" height="258" alt="Bildschirmfoto 2026-06-18 um 21 22 42" src="https://github.com/user-attachments/assets/0af68182-6ad3-4bf5-9da9-764d2522a9e5" />

After: 


## ✅ PR Checklist

- [ ] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized spacing in expanded category sections for enhanced visual layout and organization
  * Updated evaluation form styling with adjusted visual presentation of completed states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->