### PR TITLE
Renovate: update renovate configuration to enable semantic commits and set commit message prefix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "semanticCommits": "disabled",
+  "commitMessagePrefix": "Dependencies:",
   "prConcurrentLimit": 3,
   "rangeStrategy": "bump",
   "minimumReleaseAge": "7 days",


### PR DESCRIPTION
# 📝 Pull Request Template

## ✨ What is the change?

Updates the Renovate configuration so dependency update PRs use the project's established naming scheme: semantic commit formatting is disabled and the commit-message prefix is set to `Dependencies:`.

## 📌 Reason for the change / Link to issue

Align automated Renovate PR titles and commits with the repository's dependency-update naming convention. Closes #1696.

## 🧪 How to Test

1. Run `jq empty renovate.json` to validate the configuration is valid JSON.
2. Review a subsequent Renovate dependency update to confirm its title/commit message begins with `Dependencies:` and does not use semantic-commit formatting.

## 🖼️ Screenshots (if UI changes are included)

N/A — this change affects automated dependency-update metadata only.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed) — not applicable; configuration-only change
- [ ] Screenshots attached for UI changes (if any) — not applicable; no UI change
- [ ] Documentation updated (if relevant) — not applicable; internal automation configuration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Modified dependency update automation settings to apply a consistent "Dependencies:" prefix to all automated update commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->