### PR TITLE
filter out non course phase microservices

### DIFF
--- a/clients/core/src/managementConsole/pages/SystemStatusPage/SystemStatusPage.tsx
+++ b/clients/core/src/managementConsole/pages/SystemStatusPage/SystemStatusPage.tsx
@@ -5,8 +5,16 @@ import { CoursePhaseType } from './interfaces/coursePhaseType'
 import { getServiceInfo } from './network/getServiceCapabilities'
 import { useGetCoursePhaseTypes } from './hooks/useGetCoursePhaseTypes'
 
+const isMicroserviceBaseUrl = (baseUrl: string): boolean => {
+  const url = baseUrl.trim().toLowerCase()
+  return url.startsWith('http://') || url.startsWith('https://')
+}
+
 export const SystemStatusPage = () => {
-  const { data: coursePhaseTypes = [] } = useGetCoursePhaseTypes()
+  const { data: allCoursePhaseTypes = [] } = useGetCoursePhaseTypes()
+  const coursePhaseTypes = allCoursePhaseTypes.filter((service) =>
+    isMicroserviceBaseUrl(service.baseUrl),
+  )
 
   const results = useQueries({
     queries: coursePhaseTypes.map((service) => {


### PR DESCRIPTION

Fully described here:
fixes #1713 

now, as usual non course phase microservices are filtered out from course phase types simply by checking the base url

## 🧪 How to Test

1. visist admin status page
2. find that non course phase microservices are correctly filtered out

## 🖼️ Screenshots (if UI changes are included)

no UI changes.

## ✅ PR Checklist

- [ ] Tested locally or on the dev environment
- [ ] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System Status page now filters services to include only those with valid HTTP/HTTPS URLs (case-insensitive). This affects service availability classification and determines which service cards render on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->