### PR TITLE
`DevOpsChallenge`: Remove leftover styles from devops challenge component

### DIFF
--- a/clients/devops_challenge_component/src/styles.css
+++ b/clients/devops_challenge_component/src/styles.css
@@ -1,5 +1,0 @@
-@import 'tailwindcss';
-
-@import '../../tailwind-base.css';
-
-@config '../tailwind.config.js';


### PR DESCRIPTION
# 📝 Pull Request Template

## ✨ What is the change?

Removes the obsolete `styles.css` file from the DevOps Challenge component. The file only contained leftover Tailwind configuration imports and is no longer used by the component.

## 📌 Reason for the change / Link to issue

Resolves #1715.

## 🧪 How to Test

1. Inspect the DevOps Challenge component source and confirm it has no reference to `styles.css`.
2. Build or run the DevOps Challenge component in the target environment and confirm its existing styling loads as before.

## 🖼️ Screenshots (if UI changes are included)

N/A — this removes an unused stylesheet and does not change the UI.

## ✅ PR Checklist

- [ ] Tested locally or on the dev environment (not run; the removed component source is not present in this checkout)
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (not needed for unused stylesheet removal)
- [ ] Screenshots attached for UI changes (not applicable)
- [ ] Documentation updated (not applicable)
