### PR TITLE
chore: bump version to 2.14.0 for all components

### DIFF
--- a/clients/assessment_component/package.json
+++ b/clients/assessment_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assessment_component",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/certificate_component/package.json
+++ b/clients/certificate_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certificate_component",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/core/package.json
+++ b/clients/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/interview_component/package.json
+++ b/clients/interview_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interview_component",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/matching_component/package.json
+++ b/clients/matching_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matching_component",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/package.json
+++ b/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prompt-module-federation",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/clients/self_team_allocation_component/package.json
+++ b/clients/self_team_allocation_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self_team_allocation_component",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/team_allocation_component/package.json
+++ b/clients/team_allocation_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team_allocation_component",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/template_component/package.json
+++ b/clients/template_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template_component",
-  "version": "2.13.2",
+  "version": "2.14.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Bumps the version of all client components from `2.13.2` to `2.14.0` ahead of the next release.

This release adds new export integrations (Interview, Team Allocation, Self Team Allocation), self & peer evaluation result pages, the PROMPT side of Tease ↔ PROMPT team allocation auto import/export, and the webpack → rspack build migration — warranting a minor version bump rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)