### PR TITLE
ci: unify setup-go cache key to cut Actions cache usage

### DIFF
--- a/.github/workflows/generate-api-spec.yml
+++ b/.github/workflows/generate-api-spec.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: stable
-          cache-dependency-path: "**/*.sum"
+          cache-dependency-path: "servers/**/*.sum"
       - name: Install swag
         run: |
           go install github.com/swaggo/swag/cmd/swag@latest

--- a/.github/workflows/quality-servers.yml
+++ b/.github/workflows/quality-servers.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: stable
-          cache-dependency-path: "servers/${{ matrix.module }}/*.sum"
+          cache-dependency-path: "servers/**/*.sum"
       - name: Install dependencies
         run: go mod download
       - name: Install sqlc

--- a/.github/workflows/test-servers.yml
+++ b/.github/workflows/test-servers.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: stable
-          cache-dependency-path: "**/*.sum"
+          cache-dependency-path: "servers/**/*.sum"
       - name: Install dependencies
         run: cd servers/${{ matrix.directory }} && go mod download
       - name: Test with Go


### PR DESCRIPTION
## ✨ What is the change?

Point all three Go workflows at the same `cache-dependency-path: "servers/**/*.sum"`:

- `quality-servers.yml` — was per-module `servers/${{ matrix.module }}/*.sum`
- `test-servers.yml` — was `**/*.sum`
- `generate-api-spec.yml` — was `**/*.sum`

## 📌 Reason for the change

The repo's GitHub Actions cache had grown to **10.33 GB across 77 entries — over GitHub's
10 GB/repo limit**, so caches were being evicted before they could be reused (thrashing).

`quality-servers` keyed the Go cache **per module**, producing 7 near-identical `setup-go`
caches (~3.13 GB group), each holding a full copy of the largely-shared module cache. The other
two Go workflows used a different global key, so nothing shared. Converging all three on one
`servers/**/*.sum` key collapses those 7 caches into a single shared lineage per Go version —
the largest controllable win.

For context, the other big consumers were investigated and left as-is on purpose:
- **CodeQL (~5 GB)** is a transient pile-up of one ~1.24 GB Go-dependency cache that GitHub
  auto-evicts to ~1–2 copies; languages are already minimal (Go + JS/TS). Not worth changing.
- **binfmt/QEMU (0.75 GB)** lives in the shared `ls1intum/.github` reusable workflow; out of scope.

## 🧪 How to Test

1. Let CI run on this PR.
2. In the `quality-servers`, `test-servers`, and `generate-api-spec` job logs, confirm the Go
   jobs still pass and the "Cache restored/saved" lines now reference the same
   `setup-go-...-<hash(servers/**/*.sum)>` key prefix.
3. After merge, confirm the 7 per-module `setup-go` caches no longer regenerate
   (`gh cache list`) and the total footprint settles under 10 GB.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Go dependency caching for server-related workflows to better match the relevant module files.
  * This should improve cache accuracy and make API spec generation, quality checks, and server tests run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->