### PR TITLE
`Assessment`: Scope pass/fail controls to the current course's lecturers

### DIFF
--- a/clients/assessment_component/src/assessment/pages/AssessmentPage/components/PassStatusControls.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentPage/components/PassStatusControls.tsx
@@ -1,5 +1,13 @@
+import { useParams } from 'react-router-dom'
+
 import { Button } from '@tumaet/prompt-ui-components'
-import { PassStatus, Role, useAuthStore } from '@tumaet/prompt-shared-state'
+import {
+  PassStatus,
+  Role,
+  getPermissionString,
+  useAuthStore,
+  useCourseStore,
+} from '@tumaet/prompt-shared-state'
 
 import { useUpdateCoursePhaseParticipation } from '@tumaet/prompt-shared-state'
 
@@ -10,7 +18,9 @@ interface PassStatusControlsProps {
 }
 
 export const PassStatusControls = ({ courseParticipationID }: PassStatusControlsProps) => {
+  const { courseId } = useParams<{ courseId: string }>()
   const { permissions } = useAuthStore()
+  const { courses } = useCourseStore()
   const { participations } = useParticipationStore()
   const participant = participations.find(
     (participation) => participation.courseParticipationID === courseParticipationID,
@@ -18,14 +28,15 @@ export const PassStatusControls = ({ courseParticipationID }: PassStatusControls
 
   const { mutate: updateParticipation, isPending } = useUpdateCoursePhaseParticipation()
 
-  const isLecturerOrHigher = permissions.some(
-    (permission) =>
-      permission === Role.PROMPT_ADMIN ||
-      permission === Role.PROMPT_LECTURER ||
-      permission.endsWith(Role.COURSE_LECTURER),
-  )
+  const course = courses.find((c) => c.id === courseId)
+  const canSetPassStatus =
+    permissions.includes(getPermissionString(Role.PROMPT_ADMIN)) ||
+    permissions.includes(getPermissionString(Role.PROMPT_LECTURER)) ||
+    permissions.includes(
+      getPermissionString(Role.COURSE_LECTURER, course?.name, course?.semesterTag),
+    )
 
-  if (!isLecturerOrHigher || !participant || !courseParticipationID) {
+  if (!canSetPassStatus || !participant || !courseParticipationID) {
     return null
   }
 


### PR DESCRIPTION
## ✨ What is the change?

The `Set Passed` / `Set Failed` controls on a participant's assessment page are now shown only to users who can actually use them: PROMPT admins, global lecturers, and **lecturers of the current course**.

Previously the gate checked `permission.endsWith('Lecturer')`, which matched the lecturer role of *any* course. A lecturer of a different course therefore saw the buttons, clicked them, and the core `PUT /course_phases/:id/participations/:cpid` endpoint rejected the request with a 403 (the request fails silently in the UI, so it looked like "nothing happens"). Editors were already excluded on both client and server.

The check now builds the current course's lecturer permission via `getPermissionString(Role.COURSE_LECTURER, course?.name, course?.semesterTag)` and tests exact membership, mirroring the existing pattern in `NameEditingHeader` and `PermissionRestriction`.

## 📌 Reason for the change / Link to issue

Closes #1721

## 🧪 How to Test

1. Open a course's Assessment phase and go to `Participants` → a single participant's assessment page.
2. As a **lecturer of that course** (or a PROMPT admin/lecturer): the `Set Passed` / `Set Failed` controls are visible and work.
3. As a **lecturer of a different course** (not this one): the controls are no longer shown.
4. As an **editor** or **student**: the controls are not shown (unchanged).

## 🖼️ Screenshots (if UI changes are included)

N/A (the controls are conditionally hidden; no visual restyling).

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
