### PR TITLE
`Core`: directly set permissions after token refresh after course creation

### DIFF
--- a/clients/core/src/keycloak/useKeycloak.tsx
+++ b/clients/core/src/keycloak/useKeycloak.tsx
@@ -34,6 +34,33 @@ export const useKeycloak = (): {
 
   const { keycloakUrl, keycloakRealmName, keycloakValue } = context
 
+  // re-set app state from incoming token
+  const syncStateFromToken = useCallback(
+    (keycloak: Keycloak) => {
+      localStorage.setItem('jwt_token', keycloak.token ?? '')
+      localStorage.setItem('refreshToken', keycloak.refreshToken ?? '')
+
+      if (keycloak.token) {
+        const decodedJwt = parseJwt(keycloak.token)
+        if (decodedJwt) {
+          setUser({
+            firstName: decodedJwt.given_name || '',
+            lastName: decodedJwt.family_name || '',
+            email: decodedJwt.email || '',
+            username: decodedJwt.preferred_username || '',
+            matriculationNumber: decodedJwt.matriculation_number || '',
+            universityLogin: decodedJwt.university_login || '',
+          })
+        } else {
+          clearUser()
+        }
+        const resourceRoles = keycloak.resourceAccess?.['prompt-server']?.roles || []
+        setPermissions(resourceRoles)
+      }
+    },
+    [setUser, clearUser, setPermissions],
+  )
+
   const initializeKeycloak = useCallback(() => {
     const keycloak = new Keycloak({
       realm: keycloakRealmName,
@@ -44,10 +71,7 @@ export const useKeycloak = (): {
     keycloak.onTokenExpired = () => {
       keycloak
         .updateToken(5)
-        .then(() => {
-          localStorage.setItem('jwt_token', keycloak.token ?? '')
-          localStorage.setItem('refreshToken', keycloak.refreshToken ?? '')
-        })
+        .then(() => syncStateFromToken(keycloak))
         .catch(() => {
           clearUser()
           clearPermissions()
@@ -59,27 +83,8 @@ export const useKeycloak = (): {
     void keycloak
       .init({ onLoad: 'login-required' })
       .then(() => {
-        localStorage.setItem('jwt_token', keycloak.token ?? '')
-        localStorage.setItem('refreshToken', keycloak.refreshToken ?? '')
         context.keycloakValue = keycloak // Update context dynamically
-
-        if (keycloak.token) {
-          const decodedJwt = parseJwt(keycloak.token)
-          if (decodedJwt) {
-            setUser({
-              firstName: decodedJwt.given_name || '',
-              lastName: decodedJwt.family_name || '',
-              email: decodedJwt.email || '',
-              username: decodedJwt.preferred_username || '',
-              matriculationNumber: decodedJwt.matriculation_number || '',
-              universityLogin: decodedJwt.university_login || '',
-            })
-          } else {
-            clearUser()
-          }
-          const resourceRoles = keycloak.resourceAccess?.['prompt-server']?.roles || []
-          setPermissions(resourceRoles)
-        }
+        syncStateFromToken(keycloak)
       })
       .catch((err) => {
         clearUser()
@@ -88,15 +93,7 @@ export const useKeycloak = (): {
       })
 
     return keycloak
-  }, [
-    context,
-    clearUser,
-    clearPermissions,
-    setUser,
-    setPermissions,
-    keycloakRealmName,
-    keycloakUrl,
-  ])
+  }, [context, clearUser, clearPermissions, syncStateFromToken, keycloakRealmName, keycloakUrl])
 
   useEffect(() => {
     if (!keycloakValue) {
@@ -124,11 +121,8 @@ export const useKeycloak = (): {
         keycloakValue
           .updateToken(1000000) // Force immediate refresh
           .then(() => {
-            localStorage.setItem('jwt_token', keycloakValue.token ?? '')
-            localStorage.setItem('refreshToken', keycloakValue.refreshToken ?? '')
-            // reset permissions to apply newly added roles without reload
-            const resourceRoles = keycloakValue.resourceAccess?.['prompt-server']?.roles || []
-            setPermissions(resourceRoles)
+            // re-sync all token-derived state so newly added roles apply without a reload
+            syncStateFromToken(keycloakValue)
             resolve() // Resolve the promise on success
           })
           .catch((err) => {

--- a/clients/core/src/keycloak/useKeycloak.tsx
+++ b/clients/core/src/keycloak/useKeycloak.tsx
@@ -126,6 +126,9 @@ export const useKeycloak = (): {
           .then(() => {
             localStorage.setItem('jwt_token', keycloakValue.token ?? '')
             localStorage.setItem('refreshToken', keycloakValue.refreshToken ?? '')
+            // reset permissions to apply newly added roles without reload
+            const resourceRoles = keycloakValue.resourceAccess?.['prompt-server']?.roles || []
+            setPermissions(resourceRoles)
             resolve() // Resolve the promise on success
           })
           .catch((err) => {

--- a/clients/core/src/keycloak/useKeycloak.tsx
+++ b/clients/core/src/keycloak/useKeycloak.tsx
@@ -34,8 +34,8 @@ export const useKeycloak = (): {
 
   const { keycloakUrl, keycloakRealmName, keycloakValue } = context
 
-  // re-set app state from incoming token
-  const syncStateFromToken = useCallback(
+  // set app state from incoming token
+  const setStateFromToken = useCallback(
     (keycloak: Keycloak) => {
       localStorage.setItem('jwt_token', keycloak.token ?? '')
       localStorage.setItem('refreshToken', keycloak.refreshToken ?? '')
@@ -71,7 +71,7 @@ export const useKeycloak = (): {
     keycloak.onTokenExpired = () => {
       keycloak
         .updateToken(5)
-        .then(() => syncStateFromToken(keycloak))
+        .then(() => setStateFromToken(keycloak))
         .catch(() => {
           clearUser()
           clearPermissions()
@@ -84,7 +84,7 @@ export const useKeycloak = (): {
       .init({ onLoad: 'login-required' })
       .then(() => {
         context.keycloakValue = keycloak // Update context dynamically
-        syncStateFromToken(keycloak)
+        setStateFromToken(keycloak)
       })
       .catch((err) => {
         clearUser()
@@ -93,7 +93,7 @@ export const useKeycloak = (): {
       })
 
     return keycloak
-  }, [context, clearUser, clearPermissions, syncStateFromToken, keycloakRealmName, keycloakUrl])
+  }, [context, clearUser, clearPermissions, setStateFromToken, keycloakRealmName, keycloakUrl])
 
   useEffect(() => {
     if (!keycloakValue) {
@@ -121,8 +121,7 @@ export const useKeycloak = (): {
         keycloakValue
           .updateToken(1000000) // Force immediate refresh
           .then(() => {
-            // re-sync all token-derived state so newly added roles apply without a reload
-            syncStateFromToken(keycloakValue)
+            setStateFromToken(keycloakValue)
             resolve() // Resolve the promise on success
           })
           .catch((err) => {

--- a/clients/core/src/keycloak/useKeycloak.tsx
+++ b/clients/core/src/keycloak/useKeycloak.tsx
@@ -40,25 +40,25 @@ export const useKeycloak = (): {
       localStorage.setItem('jwt_token', keycloak.token ?? '')
       localStorage.setItem('refreshToken', keycloak.refreshToken ?? '')
 
-      if (keycloak.token) {
-        const decodedJwt = parseJwt(keycloak.token)
-        if (decodedJwt) {
-          setUser({
-            firstName: decodedJwt.given_name || '',
-            lastName: decodedJwt.family_name || '',
-            email: decodedJwt.email || '',
-            username: decodedJwt.preferred_username || '',
-            matriculationNumber: decodedJwt.matriculation_number || '',
-            universityLogin: decodedJwt.university_login || '',
-          })
-        } else {
-          clearUser()
-        }
-        const resourceRoles = keycloak.resourceAccess?.['prompt-server']?.roles || []
-        setPermissions(resourceRoles)
+      const decodedJwt = keycloak.token ? parseJwt(keycloak.token) : null
+      if (!decodedJwt) {
+        clearUser()
+        clearPermissions()
+        return
       }
+
+      setUser({
+        firstName: decodedJwt.given_name || '',
+        lastName: decodedJwt.family_name || '',
+        email: decodedJwt.email || '',
+        username: decodedJwt.preferred_username || '',
+        matriculationNumber: decodedJwt.matriculation_number || '',
+        universityLogin: decodedJwt.university_login || '',
+      })
+      const resourceRoles = keycloak.resourceAccess?.['prompt-server']?.roles || []
+      setPermissions(resourceRoles)
     },
-    [setUser, clearUser, setPermissions],
+    [setUser, clearUser, setPermissions, clearPermissions],
   )
 
   const initializeKeycloak = useCallback(() => {


### PR DESCRIPTION
## ✨ What is the change?

After creating a course using the AddCourseDialog, the keycloak token was already force refreshed. using forceRefreshToken.

This method however only stores the new token in local storage, which doesn't apply it to the zustand auth store.

The fix simply sets the roles inside the auth store to to those of the new token

This fixes the problem because the two routes were hidden straight after creation because the new corresponding Course_Lecturer 'role' wasn't in the local store yet.

the new token inside localstorage did work for following requests because outgoing requests always use the token from local storage

---

update: i was wondering, why we wouldn't just share the same code here as when we initialily fetch the token (after all, they are supposed to do the same thing: manual token refresh and inital), I now switched it so for manual, automatic and initial token refresh, they all share the same code path, which also cleans up the code

## 📌 Reason for the change / Link to issue

fixes #1041

## 🧪 How to Test

1. as a non admin (Prompt_Lecturere) create a course
2. notice, without relaoding you can see course configurator and settings in the sidebar menu

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
|   |  <img width="800" height="582" alt="2026-06-26 at 00 29 31" src="https://github.com/user-attachments/assets/5446242b-56a6-45e1-94bb-2bdbeef0b492" /> |

## ✅ PR Checklist

- [ ] Tested locally or on the dev environment
- [ ] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling so user details and permissions stay up to date after sign-in, token refreshes, and app startup.
  * Fixed cases where user info could be missing or stale if token decoding failed or refreshed tokens were applied inconsistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->