### PR TITLE
`Application`: No longer copy custom score in application phase during course copy

### DIFF
--- a/clients/core/src/network/queries/additionalScoreNames.ts
+++ b/clients/core/src/network/queries/additionalScoreNames.ts
@@ -5,7 +5,10 @@ export const getAdditionalScoreNames = async (
   coursePhaseId: string,
 ): Promise<AdditionalScore[]> => {
   try {
-    return (await axiosInstance.get(`/api/applications/${coursePhaseId}/score`)).data
+    const { data } = await axiosInstance.get<AdditionalScore[] | null>(
+      `/api/applications/${coursePhaseId}/score`,
+    )
+    return data ?? []
   } catch (err) {
     console.error(err)
     throw err

--- a/servers/core/course/copy/copy_phases.go
+++ b/servers/core/course/copy/copy_phases.go
@@ -54,6 +54,8 @@ func copyCoursePhases(c *gin.Context, qtx *db.Queries, sourceID, targetID uuid.U
 		}
 		delete(sanitizedRestrictedData, "applicationStartDate")
 		delete(sanitizedRestrictedData, "applicationEndDate")
+		sanitizedRestrictedData["useCustomScores"] = false
+		delete(sanitizedRestrictedData, "additionalScores")
 
 		newPhase := coursePhaseDTO.CreateCoursePhase{
 			Name:                phase.Name,


### PR DESCRIPTION
## ✨ What is the change?

the score data and customs cores toggle is entirely scored inside the course records restricted Data.
The PR adjusts the restricted Data that is copied:
- it removes the key 'additionalScores', where the custom scores are stored
- it sets useCustomScores to false

also adjust the getAdditionalScore query in the frontend to return an empty list instead of null when there are no scores returned.
This is so the application wrapper can tell the loading state from no courses state.
That way the empty scores are updated straight away, not requiring a browser reload to show (previously the old scores were still stale in the application zustand store)

## 📌 Reason for the change / Link to issue

fixes #745

## 🧪 How to Test

1. create / open a course that has custom scores enabled and at least one custom score listed
2. open the course settings, open the danger zone and initiate a course copy
3. fill out the form and copy the course
4. verify that on the newly created course, the custom scores are not visible in the application participants table

## 🖼️ Screenshots (if UI changes are included)

Before:
copying a course would copy over the custom score definitions. However, with a course copy we're not copying over participation data anyway so the empty score is useless

After:
 <img width="800" height="572" alt="2026-06-27 at 10 18 20" src="https://github.com/user-attachments/assets/943d2751-fe58-4b5a-88bf-9db0aceb4ae8" /> 

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)