### PR TITLE
`Core`: improve token verification logging and add tests for logging behavior

### DIFF
--- a/docker-compose.extern.prod.yml
+++ b/docker-compose.extern.prod.yml
@@ -65,6 +65,7 @@ services:
       - SENDER_NAME
       - SENTRY_DSN_CORE
       - SENTRY_ENABLED
+      - GITHUB_SHA
     networks:
       - prompt-network
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -97,6 +97,7 @@ services:
       - SENDER_NAME
       - SENTRY_DSN_CORE
       - SENTRY_ENABLED
+      - GITHUB_SHA
       - S3_BUCKET
       - S3_REGION
       - S3_ENDPOINT
@@ -139,6 +140,7 @@ services:
       - KEYCLOAK_REALM_NAME
       - SENTRY_DSN_TEAM_ALLOCATION
       - SENTRY_ENABLED
+      - GITHUB_SHA
     networks:
       - prompt-network
 
@@ -171,6 +173,7 @@ services:
       - KEYCLOAK_REALM_NAME
       - SENTRY_DSN_SELF_TEAM_ALLOCATION
       - SENTRY_ENABLED
+      - GITHUB_SHA
     networks:
       - prompt-network
 
@@ -203,6 +206,7 @@ services:
       - KEYCLOAK_REALM_NAME
       - SENTRY_DSN_ASSESSMENT
       - SENTRY_ENABLED
+      - GITHUB_SHA
     networks:
       - prompt-network
 
@@ -236,6 +240,7 @@ services:
       - KEYCLOAK_REALM_NAME
       - SENTRY_DSN_INTERVIEW
       - SENTRY_ENABLED
+      - GITHUB_SHA
     networks:
       - prompt-network
 
@@ -270,6 +275,7 @@ services:
       - KEYCLOAK_AUTHORIZED_PARTY
       - SENTRY_DSN_CERTIFICATE
       - SENTRY_ENABLED
+      - GITHUB_SHA
     networks:
       - prompt-network
 

--- a/servers/core/keycloakTokenVerifier/applicationMiddleware.go
+++ b/servers/core/keycloakTokenVerifier/applicationMiddleware.go
@@ -19,7 +19,7 @@ func ApplicationMiddleware() gin.HandlerFunc {
 		ctx := c.Request.Context()
 		idToken, err := verifier.Verify(ctx, tokenString)
 		if err != nil {
-			log.Error("Failed to validate token: ", err)
+			logTokenVerificationFailure(err)
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
 			return
 		}

--- a/servers/core/keycloakTokenVerifier/middleware.go
+++ b/servers/core/keycloakTokenVerifier/middleware.go
@@ -33,7 +33,7 @@ func KeycloakMiddleware() gin.HandlerFunc {
 		ctx := c.Request.Context()
 		idToken, err := verifier.Verify(ctx, tokenString)
 		if err != nil {
-			log.Error("Failed to validate token: ", err)
+			logTokenVerificationFailure(err)
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
 			return
 		}
@@ -119,6 +119,17 @@ func KeycloakMiddleware() gin.HandlerFunc {
 		c.Set(CtxLastName, lastName)
 		c.Next()
 	}
+}
+
+// logTokenVerificationFailure logs a failed token verification, downgrading the routine
+// expired-token case to Debug so it is not reported to Sentry as an error.
+func logTokenVerificationFailure(err error) {
+	var expiredErr *oidc.TokenExpiredError
+	if errors.As(err, &expiredErr) {
+		log.Debug("Rejected expired token: ", err)
+		return
+	}
+	log.Error("Failed to validate token: ", err)
 }
 
 // extractBearerToken retrieves and validates the Bearer token from the request's Authorization header.

--- a/servers/core/keycloakTokenVerifier/middleware_test.go
+++ b/servers/core/keycloakTokenVerifier/middleware_test.go
@@ -24,8 +24,14 @@ func TestLogTokenVerificationFailure(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			prevLevel := log.GetLevel()
+			prevHooks := log.StandardLogger().Hooks
 			hook := test.NewGlobal()
 			log.SetLevel(log.DebugLevel)
+			t.Cleanup(func() {
+				log.SetLevel(prevLevel)
+				log.StandardLogger().ReplaceHooks(prevHooks)
+			})
 
 			logTokenVerificationFailure(tt.err)
 

--- a/servers/core/keycloakTokenVerifier/middleware_test.go
+++ b/servers/core/keycloakTokenVerifier/middleware_test.go
@@ -1,0 +1,41 @@
+package keycloakTokenVerifier
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestLogTokenVerificationFailure(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantLevel log.Level
+	}{
+		{"expired token", &oidc.TokenExpiredError{Expiry: time.Now()}, log.DebugLevel},
+		{"wrapped expired token", fmt.Errorf("verify: %w", &oidc.TokenExpiredError{Expiry: time.Now()}), log.DebugLevel},
+		{"generic failure", errors.New("token signature is invalid"), log.ErrorLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := test.NewGlobal()
+			log.SetLevel(log.DebugLevel)
+
+			logTokenVerificationFailure(tt.err)
+
+			entry := hook.LastEntry()
+			if entry == nil {
+				t.Fatal("expected a log entry, got none")
+			}
+			if entry.Level != tt.wantLevel {
+				t.Fatalf("expected level %v, got %v", tt.wantLevel, entry.Level)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Expired token verification failures in the core Keycloak token verifier are now handled through a shared logging helper. Routine expired-token rejections are logged at debug level so they are not reported to Sentry as errors, while all other token validation failures continue to be logged as errors.

The helper is used by both the main Keycloak middleware and the reduced application middleware. Focused tests cover direct expired-token errors, wrapped expired-token errors, and generic verification failures.

## 📌 Reason for the change / Link to issue

Fixes #1175: https://github.com/prompt-edu/prompt/issues/1175

## 🧪 How to Test

1. `cd servers/core`
2. `go test ./keycloakTokenVerifier`

## 🖼️ Screenshots (if UI changes are included)

N/A - backend logging behavior only, no UI changes.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expired-token verification failures are now logged at a lower (debug) level to reduce unnecessary error noise.
  * Other token verification failures still log as errors and behave the same for authentication (HTTP 401 with “Invalid token”).
* **DevOps**
  * Added `GITHUB_SHA` to production runtime environment variables for the backend services, including the external production server container, to expose the build identifier at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->