### PR TITLE
`Application`: Fix student email sync for authenticated applications

### DIFF
--- a/servers/core/applicationAdministration/router.go
+++ b/servers/core/applicationAdministration/router.go
@@ -214,12 +214,14 @@ func getApplicationAuthenticated(c *gin.Context) {
 	}
 
 	if applicationForm.Student != nil && userEmail != "" {
+		storedEmail := applicationForm.Student.Email
 		applicationForm.Student.Email = userEmail
 		if firstName != "" && lastName != "" {
 			applicationForm.Student.FirstName = firstName
 			applicationForm.Student.LastName = lastName
 		}
 		if err := SyncStudentDetailsFromToken(c, *applicationForm.Student); err != nil {
+			applicationForm.Student.Email = storedEmail
 			log.Warn("could not sync student details from token: ", err)
 		}
 	}
@@ -396,9 +398,7 @@ func postApplicationAuthenticated(c *gin.Context) {
 		return
 	}
 
-	if userEmail != "" {
-		application.Student.Email = userEmail
-	}
+	application.Student.Email = userEmail
 	if firstName != "" && lastName != "" {
 		application.Student.FirstName = firstName
 		application.Student.LastName = lastName

--- a/servers/core/applicationAdministration/router.go
+++ b/servers/core/applicationAdministration/router.go
@@ -236,6 +236,7 @@ func getApplicationAuthenticated(c *gin.Context) {
 // @Success 201 {object} map[string]interface{}
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 405 {object} utils.ErrorResponse
+// @Failure 409 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
 // @Router /applications/{coursePhaseID} [post]
 func postApplicationManual(c *gin.Context) {
@@ -262,6 +263,9 @@ func postApplicationManual(c *gin.Context) {
 		log.Error(err)
 		if errors.Is(err, ErrAlreadyApplied) {
 			handleError(c, http.StatusMethodNotAllowed, errors.New("already applied"))
+			return
+		} else if errors.Is(err, ErrEmailAlreadyInUse) {
+			handleError(c, http.StatusConflict, errors.New("email already in use"))
 			return
 		}
 
@@ -350,6 +354,7 @@ func postApplicationExtern(c *gin.Context) {
 // @Success 201 {object} map[string]interface{}
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 401 {object} utils.ErrorResponse
+// @Failure 409 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
 // @Router /apply/authenticated/{coursePhaseID} [post]
 func postApplicationAuthenticated(c *gin.Context) {
@@ -399,6 +404,10 @@ func postApplicationAuthenticated(c *gin.Context) {
 	courseParticipationID, err := PostApplicationAuthenticatedStudent(c, coursePhaseId, application)
 	if err != nil {
 		log.Error(err)
+		if errors.Is(err, ErrEmailAlreadyInUse) {
+			handleError(c, http.StatusConflict, errors.New("email already in use"))
+			return
+		}
 		handleError(c, http.StatusInternalServerError, errors.New("could not post application"))
 		return
 	}

--- a/servers/core/applicationAdministration/router.go
+++ b/servers/core/applicationAdministration/router.go
@@ -215,10 +215,13 @@ func getApplicationAuthenticated(c *gin.Context) {
 
 	if applicationForm.Student != nil && userEmail != "" {
 		applicationForm.Student.Email = userEmail
-	}
-	if applicationForm.Student != nil && firstName != "" && lastName != "" {
-		applicationForm.Student.FirstName = firstName
-		applicationForm.Student.LastName = lastName
+		if firstName != "" && lastName != "" {
+			applicationForm.Student.FirstName = firstName
+			applicationForm.Student.LastName = lastName
+		}
+		if err := SyncStudentDetailsFromToken(c, *applicationForm.Student); err != nil {
+			log.Warn("could not sync student details from token: ", err)
+		}
 	}
 
 	c.IndentedJSON(http.StatusOK, applicationForm)

--- a/servers/core/applicationAdministration/router.go
+++ b/servers/core/applicationAdministration/router.go
@@ -204,6 +204,7 @@ func getApplicationAuthenticated(c *gin.Context) {
 
 	firstName := c.GetString("firstName")
 	lastName := c.GetString("lastName")
+	userEmail := c.GetString("userEmail")
 
 	applicationForm, err := GetApplicationAuthenticatedByMatriculationNumberAndUniversityLogin(c, coursePhaseID, matriculationNumber, universityLogin)
 	if err != nil {
@@ -212,6 +213,9 @@ func getApplicationAuthenticated(c *gin.Context) {
 		return
 	}
 
+	if applicationForm.Student != nil && userEmail != "" {
+		applicationForm.Student.Email = userEmail
+	}
 	if applicationForm.Student != nil && firstName != "" && lastName != "" {
 		applicationForm.Student.FirstName = firstName
 		applicationForm.Student.LastName = lastName
@@ -378,13 +382,15 @@ func postApplicationAuthenticated(c *gin.Context) {
 		return
 	}
 
-	if application.Student.Email != userEmail ||
-		application.Student.MatriculationNumber != matriculationNumber ||
+	if application.Student.MatriculationNumber != matriculationNumber ||
 		application.Student.UniversityLogin != universityLogin {
 		handleError(c, http.StatusUnauthorized, errors.New("credentials do not match payload"))
 		return
 	}
 
+	if userEmail != "" {
+		application.Student.Email = userEmail
+	}
 	if firstName != "" && lastName != "" {
 		application.Student.FirstName = firstName
 		application.Student.LastName = lastName

--- a/servers/core/applicationAdministration/router_test.go
+++ b/servers/core/applicationAdministration/router_test.go
@@ -349,6 +349,21 @@ func (suite *ApplicationAdminRouterTestSuite) TestGetApplicationAuthenticatedEnd
 	assert.Equal(suite.T(), "existingstudent@example.com", application.Student.Email)
 }
 
+func (suite *ApplicationAdminRouterTestSuite) TestGetApplicationAuthenticatedEndpoint_PersistsTokenEmailToDB() {
+	originalEmail := suite.getStudentEmail()
+	defer suite.setStudentEmail(originalEmail)
+	suite.setStudentEmail("stale@example.com")
+
+	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
+	req := httptest.NewRequest(http.MethodGet, "/api/apply/authenticated/"+coursePhaseID, nil)
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+
+	assert.Equal(suite.T(), http.StatusOK, resp.Code)
+	assert.Equal(suite.T(), "existingstudent@example.com", suite.getStudentEmail())
+}
+
 func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEndpoint_SyncsTokenEmailWhenStale() {
 	originalEmail := suite.getStudentEmail()
 	defer suite.setStudentEmail(originalEmail)

--- a/servers/core/applicationAdministration/router_test.go
+++ b/servers/core/applicationAdministration/router_test.go
@@ -262,13 +262,12 @@ func (suite *ApplicationAdminRouterTestSuite) TestGetApplicationAuthenticatedEnd
 	assert.Equal(suite.T(), applicationDTO.StatusNotApplied, application.Status)
 }
 
-func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEndpoint_Success() {
-	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
-	application := applicationDTO.PostApplication{
+func authApplicationWithEmail(email string) applicationDTO.PostApplication {
+	return applicationDTO.PostApplication{
 		Student: studentDTO.CreateStudent{
 			FirstName:            "John",
 			LastName:             "Doe",
-			Email:                "existingstudent@example.com",
+			Email:                email,
 			Gender:               db.GenderDiverse,
 			HasUniversityAccount: true,
 			MatriculationNumber:  "03711111",
@@ -297,8 +296,11 @@ func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEn
 			},
 		},
 	}
+}
 
-	jsonBody, err := json.Marshal(application)
+func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEndpoint_Success() {
+	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
+	jsonBody, err := json.Marshal(authApplicationWithEmail("existingstudent@example.com"))
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/apply/authenticated/"+coursePhaseID, bytes.NewReader(jsonBody))
@@ -350,41 +352,7 @@ func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEn
 	suite.setStudentEmail("stale@example.com")
 
 	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
-	application := applicationDTO.PostApplication{
-		Student: studentDTO.CreateStudent{
-			FirstName:            "John",
-			LastName:             "Doe",
-			Email:                "stale@example.com",
-			Gender:               db.GenderDiverse,
-			HasUniversityAccount: true,
-			MatriculationNumber:  "03711111",
-			UniversityLogin:      "ab12cde",
-			Nationality:          "DE",
-			CurrentSemester:      pgtype.Int4{Valid: true, Int32: 1},
-			StudyProgram:         "Computer Science",
-			StudyDegree:          "bachelor",
-		},
-		AnswersText: []applicationDTO.CreateAnswerText{
-			{
-				ApplicationQuestionID: uuid.MustParse("a6a04042-95d1-4765-8592-caf9560c8c3c"),
-				Answer:                "Valid answer.",
-			},
-		},
-		AnswersMultiSelect: []applicationDTO.CreateAnswerMultiSelect{
-			{
-				ApplicationQuestionID: uuid.MustParse("383a9590-fba2-4e6b-a32b-88895d55fb9b"),
-				Answer:                []string{"MacBook"},
-			},
-		},
-		AnswersFileUpload: []applicationDTO.CreateAnswerFileUpload{
-			{
-				ApplicationQuestionID: requiredFileUploadQuestionID,
-				FileID:                seededUploadFileID,
-			},
-		},
-	}
-
-	jsonBody, err := json.Marshal(application)
+	jsonBody, err := json.Marshal(authApplicationWithEmail("stale@example.com"))
 	assert.NoError(suite.T(), err)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/apply/authenticated/"+coursePhaseID, bytes.NewReader(jsonBody))

--- a/servers/core/applicationAdministration/router_test.go
+++ b/servers/core/applicationAdministration/router_test.go
@@ -314,6 +314,89 @@ func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEn
 	assert.Equal(suite.T(), "application posted", responseBody["message"])
 }
 
+const seededStudentID = "3a774200-39a7-4656-bafb-92b7210a93c1"
+
+func (suite *ApplicationAdminRouterTestSuite) setStudentEmail(email string) {
+	_, err := suite.applicationAdminService.conn.Exec(suite.ctx, "UPDATE student SET email = $1 WHERE id = $2", email, seededStudentID)
+	assert.NoError(suite.T(), err)
+}
+
+func (suite *ApplicationAdminRouterTestSuite) getStudentEmail() string {
+	var email string
+	err := suite.applicationAdminService.conn.QueryRow(suite.ctx, "SELECT email FROM student WHERE id = $1", seededStudentID).Scan(&email)
+	assert.NoError(suite.T(), err)
+	return email
+}
+
+func (suite *ApplicationAdminRouterTestSuite) TestGetApplicationAuthenticatedEndpoint_ReturnsTokenEmailWhenStale() {
+	suite.setStudentEmail("stale@example.com")
+	defer suite.setStudentEmail("existingstudent@example.com")
+
+	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
+	req := httptest.NewRequest(http.MethodGet, "/api/apply/authenticated/"+coursePhaseID, nil)
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+
+	assert.Equal(suite.T(), http.StatusOK, resp.Code)
+	var application applicationDTO.Application
+	err := json.Unmarshal(resp.Body.Bytes(), &application)
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), application.Student)
+	assert.Equal(suite.T(), "existingstudent@example.com", application.Student.Email)
+}
+
+func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEndpoint_SyncsTokenEmailWhenStale() {
+	suite.setStudentEmail("stale@example.com")
+
+	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
+	application := applicationDTO.PostApplication{
+		Student: studentDTO.CreateStudent{
+			FirstName:            "John",
+			LastName:             "Doe",
+			Email:                "stale@example.com",
+			Gender:               db.GenderDiverse,
+			HasUniversityAccount: true,
+			MatriculationNumber:  "03711111",
+			UniversityLogin:      "ab12cde",
+			Nationality:          "DE",
+			CurrentSemester:      pgtype.Int4{Valid: true, Int32: 1},
+			StudyProgram:         "Computer Science",
+			StudyDegree:          "bachelor",
+		},
+		AnswersText: []applicationDTO.CreateAnswerText{
+			{
+				ApplicationQuestionID: uuid.MustParse("a6a04042-95d1-4765-8592-caf9560c8c3c"),
+				Answer:                "Valid answer.",
+			},
+		},
+		AnswersMultiSelect: []applicationDTO.CreateAnswerMultiSelect{
+			{
+				ApplicationQuestionID: uuid.MustParse("383a9590-fba2-4e6b-a32b-88895d55fb9b"),
+				Answer:                []string{"MacBook"},
+			},
+		},
+		AnswersFileUpload: []applicationDTO.CreateAnswerFileUpload{
+			{
+				ApplicationQuestionID: requiredFileUploadQuestionID,
+				FileID:                seededUploadFileID,
+			},
+		},
+	}
+
+	jsonBody, err := json.Marshal(application)
+	assert.NoError(suite.T(), err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/apply/authenticated/"+coursePhaseID, bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+
+	assert.Equal(suite.T(), http.StatusCreated, resp.Code)
+	assert.Equal(suite.T(), "existingstudent@example.com", suite.getStudentEmail())
+}
+
 func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationExternEndpoint_AlreadyApplied() {
 	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
 	application := applicationDTO.PostApplication{

--- a/servers/core/applicationAdministration/router_test.go
+++ b/servers/core/applicationAdministration/router_test.go
@@ -331,8 +331,9 @@ func (suite *ApplicationAdminRouterTestSuite) getStudentEmail() string {
 }
 
 func (suite *ApplicationAdminRouterTestSuite) TestGetApplicationAuthenticatedEndpoint_ReturnsTokenEmailWhenStale() {
+	originalEmail := suite.getStudentEmail()
+	defer suite.setStudentEmail(originalEmail)
 	suite.setStudentEmail("stale@example.com")
-	defer suite.setStudentEmail("existingstudent@example.com")
 
 	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
 	req := httptest.NewRequest(http.MethodGet, "/api/apply/authenticated/"+coursePhaseID, nil)
@@ -349,6 +350,8 @@ func (suite *ApplicationAdminRouterTestSuite) TestGetApplicationAuthenticatedEnd
 }
 
 func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEndpoint_SyncsTokenEmailWhenStale() {
+	originalEmail := suite.getStudentEmail()
+	defer suite.setStudentEmail(originalEmail)
 	suite.setStudentEmail("stale@example.com")
 
 	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"

--- a/servers/core/applicationAdministration/router_test.go
+++ b/servers/core/applicationAdministration/router_test.go
@@ -365,6 +365,23 @@ func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationAuthenticatedEn
 	assert.Equal(suite.T(), "existingstudent@example.com", suite.getStudentEmail())
 }
 
+func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationManualEndpoint_UpdatesStudentEmail() {
+	defer suite.setStudentEmail("existingstudent@example.com")
+
+	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
+	jsonBody, err := json.Marshal(authApplicationWithEmail("lecturer-updated@example.com"))
+	assert.NoError(suite.T(), err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/applications/"+coursePhaseID, bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+
+	assert.Equal(suite.T(), http.StatusCreated, resp.Code)
+	assert.Equal(suite.T(), "lecturer-updated@example.com", suite.getStudentEmail())
+}
+
 func (suite *ApplicationAdminRouterTestSuite) TestPostApplicationExternEndpoint_AlreadyApplied() {
 	coursePhaseID := "4179d58a-d00d-4fa7-94a5-397bc69fab02"
 	application := applicationDTO.PostApplication{

--- a/servers/core/applicationAdministration/service.go
+++ b/servers/core/applicationAdministration/service.go
@@ -467,20 +467,7 @@ func PostApplicationExtern(ctx context.Context, coursePhaseID uuid.UUID, applica
 }
 
 func SyncStudentDetailsFromToken(ctx context.Context, s studentDTO.Student) error {
-	_, err := student.UpdateStudent(ctx, nil, s.ID, studentDTO.CreateStudent{
-		ID:                   s.ID,
-		FirstName:            s.FirstName,
-		LastName:             s.LastName,
-		Email:                s.Email,
-		MatriculationNumber:  s.MatriculationNumber,
-		UniversityLogin:      s.UniversityLogin,
-		HasUniversityAccount: s.HasUniversityAccount,
-		Gender:               s.Gender,
-		Nationality:          s.Nationality,
-		StudyDegree:          s.StudyDegree,
-		StudyProgram:         s.StudyProgram,
-		CurrentSemester:      s.CurrentSemester,
-	})
+	_, err := student.UpdateStudent(ctx, nil, s.ID, studentDTO.CreateStudent(s))
 	return err
 }
 

--- a/servers/core/applicationAdministration/service.go
+++ b/servers/core/applicationAdministration/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	sdkUtils "github.com/prompt-edu/prompt-sdk/utils"
@@ -32,6 +33,7 @@ var ApplicationServiceSingleton *ApplicationService
 var ErrNotFound = errors.New("application was not found")
 var ErrAlreadyApplied = errors.New("application already exists")
 var ErrStudentDetailsDoNotMatch = errors.New("student details do not match")
+var ErrEmailAlreadyInUse = errors.New("email already in use")
 
 func buildFileUploadAnswerDTOs(ctx context.Context, answers []db.ApplicationAnswerFileUpload, includeDownloadURL bool) []applicationDTO.AnswerFileUpload {
 	answerDTOs := make([]applicationDTO.AnswerFileUpload, 0, len(answers))
@@ -560,6 +562,10 @@ func PostApplicationAuthenticatedStudent(ctx context.Context, coursePhaseID uuid
 	studentObj, err := student.CreateOrUpdateStudent(ctx, qtx, application.Student)
 	if err != nil {
 		log.Error(err)
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return uuid.Nil, ErrEmailAlreadyInUse
+		}
 		return uuid.Nil, errors.New("could not save the student")
 	}
 

--- a/servers/core/applicationAdministration/service.go
+++ b/servers/core/applicationAdministration/service.go
@@ -19,6 +19,7 @@ import (
 	db "github.com/prompt-edu/prompt/servers/core/db/sqlc"
 	"github.com/prompt-edu/prompt/servers/core/storage/files"
 	"github.com/prompt-edu/prompt/servers/core/student"
+	"github.com/prompt-edu/prompt/servers/core/student/studentDTO"
 	"github.com/prompt-edu/prompt/servers/core/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -463,6 +464,24 @@ func PostApplicationExtern(ctx context.Context, coursePhaseID uuid.UUID, applica
 	cleanupReplacedFiles(ctx, replacedFileIDs)
 
 	return cPhaseParticipation.CourseParticipationID, nil
+}
+
+func SyncStudentDetailsFromToken(ctx context.Context, s studentDTO.Student) error {
+	_, err := student.UpdateStudent(ctx, nil, s.ID, studentDTO.CreateStudent{
+		ID:                   s.ID,
+		FirstName:            s.FirstName,
+		LastName:             s.LastName,
+		Email:                s.Email,
+		MatriculationNumber:  s.MatriculationNumber,
+		UniversityLogin:      s.UniversityLogin,
+		HasUniversityAccount: s.HasUniversityAccount,
+		Gender:               s.Gender,
+		Nationality:          s.Nationality,
+		StudyDegree:          s.StudyDegree,
+		StudyProgram:         s.StudyProgram,
+		CurrentSemester:      s.CurrentSemester,
+	})
+	return err
 }
 
 func GetApplicationAuthenticatedByMatriculationNumberAndUniversityLogin(ctx context.Context, coursePhaseID uuid.UUID, matriculationNumber string, universityLogin string) (applicationDTO.Application, error) {

--- a/servers/core/applicationAdministration/service.go
+++ b/servers/core/applicationAdministration/service.go
@@ -563,7 +563,7 @@ func PostApplicationAuthenticatedStudent(ctx context.Context, coursePhaseID uuid
 	if err != nil {
 		log.Error(err)
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" && pgErr.ConstraintName == "student_email_key" {
 			return uuid.Nil, ErrEmailAlreadyInUse
 		}
 		return uuid.Nil, errors.New("could not save the student")

--- a/servers/core/docs/docs.go
+++ b/servers/core/docs/docs.go
@@ -66,6 +66,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/utils.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -731,6 +737,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/utils.ErrorResponse"
                         }

--- a/servers/core/docs/swagger.json
+++ b/servers/core/docs/swagger.json
@@ -60,6 +60,12 @@
                             "$ref": "#/definitions/utils.ErrorResponse"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -725,6 +731,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/utils.ErrorResponse"
                         }

--- a/servers/core/docs/swagger.yaml
+++ b/servers/core/docs/swagger.yaml
@@ -1523,6 +1523,10 @@ paths:
           description: Method Not Allowed
           schema:
             $ref: '#/definitions/utils.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/utils.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
@@ -2074,6 +2078,10 @@ paths:
             $ref: '#/definitions/utils.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/utils.ErrorResponse'
         "500":

--- a/servers/core/student/service.go
+++ b/servers/core/student/service.go
@@ -176,7 +176,7 @@ func CreateOrUpdateStudent(ctx context.Context, transactionQueries *db.Queries, 
 			ID:                   existingStudent.ID, // make sure the id is not overwritten
 			FirstName:            studentInput.FirstName,
 			LastName:             studentInput.LastName,
-			Email:                existingStudent.Email,
+			Email:                studentInput.Email,
 			MatriculationNumber:  matriculationNumber,
 			UniversityLogin:      studentInput.UniversityLogin,
 			HasUniversityAccount: studentInput.HasUniversityAccount,


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Authenticated application handling now treats the email from the authenticated token as the source of truth:

- GET `/api/apply/authenticated/:coursePhaseID` returns the token email when the stored student email is stale.
- POST `/api/apply/authenticated/:coursePhaseID` no longer rejects a payload solely because its email differs from the token email; it overwrites the submitted student email with the authenticated token email before persisting.
- `CreateOrUpdateStudent` updates the email for existing students from the incoming student data instead of keeping the old database value.
- Router tests now cover stale-email retrieval and persistence, with a helper for authenticated application payload setup.

## 📌 Reason for the change / Link to issue

Fixes #1758. When a student's email changes in TUMonline, the authenticated application flow should sync the current authenticated email instead of continuing to use or require the stale email stored in PROMPT.

## 🧪 How to Test

1. Run `cd servers/core && go test ./applicationAdministration ./student`.
2. For manual verification, set an existing student's stored email to an outdated value.
3. Authenticate as that student with the updated token email and load the authenticated application endpoint.
4. Confirm the returned application shows the updated token email and that posting the application persists that email in the student record.

## 🖼️ Screenshots (if UI changes are included)

N/A - backend application/student email handling only, no UI changes.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authenticated application views and submission endpoints now reconcile a stale saved student email with the signed-in account’s token email.
  * Authenticated submissions validate matriculation number and university login; they return **401** on mismatch and align email to the signed-in account.
  * Submissions now return **409 Conflict** when the email is already in use (including manual submissions).
  * Student record updates now always persist the latest email from the payload/token.
* **Documentation**
  * Updated API docs to include **409 Conflict** for application submission endpoints.
* **Tests**
  * Expanded tests covering token/DB email reconciliation and authenticated/manual conflict and update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->