### PR TITLE
E2E: application file-upload round-trip through SeaweedFS

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -256,6 +256,10 @@ services:
         condition: service_healthy
       seaweedfs-filer:
         condition: service_healthy
+      # Without a registered volume server the master can't assign a volume, so
+      # the first object PUT fails ("Not enough data nodes found"). Gate on it.
+      seaweedfs-volume:
+        condition: service_healthy
     restart: unless-stopped
     environment:
       - WEED_S3_DEFAULT_USER=${S3_ACCESS_KEY}

--- a/e2e/seed/e2e_seed.sql
+++ b/e2e/seed/e2e_seed.sql
@@ -652,6 +652,14 @@ INSERT INTO public.course_phase_type VALUES ('a2222222-2222-2222-2222-2222222222
 
 
 --
+-- An open Application phase on iPraktikum, so the file-upload endpoints accept
+-- uploads (applicationEndDate in the future → CheckIfCoursePhaseIsOpenApplicationPhase passes).
+--
+
+INSERT INTO public.course_phase VALUES ('aaaa1111-0000-0000-0000-0000000000a1', 'd7307be2-d3dc-496e-86f0-643bff6cc1c8', 'Application', '{"applicationEndDate": "2099-12-31T23:59:59", "universityLoginAvailable": false}', true, 'a1111111-1111-1111-1111-111111111111', '{}');
+
+
+--
 -- Data for Name: course_phase_type_participation_provided_output_dto; Type: TABLE DATA; Schema: public; Owner: -
 --
 

--- a/e2e/src/data/constants.ts
+++ b/e2e/src/data/constants.ts
@@ -22,6 +22,10 @@ export const SEEDED_COURSES = {
 // Total non-template courses present in the seed.
 export const SEEDED_COURSE_COUNT = 3
 
+// An open Application phase on iPraktikum (applicationEndDate in the far future),
+// so the application file-upload endpoints accept uploads.
+export const OPEN_APPLICATION_PHASE_ID = 'aaaa1111-0000-0000-0000-0000000000a1'
+
 export const SEEDED_STUDENT = {
   id: '3869f209-9a21-4595-ae0e-bc6d6a3e2d63',
   firstName: 'Niclas',

--- a/e2e/tests/api/application-files.api.spec.ts
+++ b/e2e/tests/api/application-files.api.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect, request, APIRequestContext } from '@playwright/test'
+import { CORE_API_URL } from '../../src/env'
+import { OPEN_APPLICATION_PHASE_ID } from '../../src/data/constants'
+
+// The external /apply endpoints are public (no token). This drives the full
+// presign → PUT-to-S3 → complete → download round-trip, so it fails if the
+// SeaweedFS wiring breaks — something the mock-backed Go tests can't catch.
+test.describe('core API: application file upload', () => {
+  let ctx: APIRequestContext
+
+  test.beforeAll(async () => {
+    ctx = await request.newContext({ baseURL: CORE_API_URL })
+  })
+  test.afterAll(async () => {
+    await ctx.dispose()
+  })
+
+  test('a file round-trips through S3 via the apply endpoints', async () => {
+    const body = Buffer.from('e2e application file contents')
+    const base = `/api/apply/${OPEN_APPLICATION_PHASE_ID}/files`
+
+    const presign = await ctx.post(`${base}/presign`, {
+      data: { filename: 'cv.pdf', contentType: 'application/pdf' },
+    })
+    expect(presign.ok(), await presign.text()).toBeTruthy()
+    const { uploadUrl, storageKey } = (await presign.json()) as {
+      uploadUrl: string
+      storageKey: string
+    }
+    expect(uploadUrl).toBeTruthy()
+    expect(storageKey).toContain(`course-phase/${OPEN_APPLICATION_PHASE_ID}/`)
+
+    // Absolute presigned URL; overrides baseURL. This is the real write to S3.
+    const put = await ctx.put(uploadUrl, {
+      headers: { 'content-type': 'application/pdf' },
+      data: body,
+    })
+    expect(put.ok(), `upload failed: ${put.status()}`).toBeTruthy()
+
+    const complete = await ctx.post(`${base}/complete`, {
+      data: {
+        storageKey,
+        originalFilename: 'cv.pdf',
+        contentType: 'application/pdf',
+      },
+    })
+    expect(complete.status(), await complete.text()).toBe(201)
+    const { downloadUrl } = (await complete.json()) as { downloadUrl: string }
+    expect(downloadUrl).toBeTruthy()
+
+    const download = await ctx.get(downloadUrl)
+    expect(download.ok()).toBeTruthy()
+    expect(await download.body()).toEqual(body)
+  })
+})


### PR DESCRIPTION
## What

Adds the first e2e test that actually exercises **SeaweedFS** — the S3 service the e2e stack already boots but no test touched until now.

The spec drives the full external application file flow end to end:

```
POST /apply/{phase}/files/presign  →  PUT to the presigned S3 URL
                                   →  POST /apply/{phase}/files/complete
                                   →  GET the download URL
```

It asserts the downloaded bytes equal the uploaded bytes, so it fails if the storage wiring breaks. The existing Go tests can't catch this — `storage/files/service_test.go` runs against a `MockStorageAdapter`, so the real presign/PUT/HEAD/GET round-trip had zero coverage anywhere.

## Changes

- **`e2e/tests/api/application-files.api.spec.ts`** — the round-trip spec (API project, no browser).
- **`e2e/seed/e2e_seed.sql`** — seeds one open `Application` phase on iPraktikum. The upload endpoints gate on `CheckIfCoursePhaseIsOpenApplicationPhase`, and the seed previously had no `course_phase` rows at all, so without this every presign returns 403.
- **`e2e/src/data/constants.ts`** — exposes the seeded phase id as `OPEN_APPLICATION_PHASE_ID`.
- **`docker-compose.e2e.yml`** — fixes a latent ordering bug surfaced by this test: `seaweedfs-s3` did not depend on `seaweedfs-volume`, so the first object PUT could fail with `Not enough data nodes found` before a volume server registered. Gated `seaweedfs-s3` on the volume's existing healthcheck.

## Testing

- `make test-e2e` (full canonical Dockerized run) — **11/11 pass** from a cold, clean-seeded start, including the existing 10.
- Verified the volume-dependency fix by reproducing the 500 (`assign volume: all filers failed`) before the change and a green round-trip after.
- `npx tsc --noEmit` clean.
