### PR TITLE
`Team Allocation`: return 404 instead of 500 on missing rows

### DIFF
--- a/servers/team_allocation/allocation/router.go
+++ b/servers/team_allocation/allocation/router.go
@@ -1,10 +1,12 @@
 package allocation
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
 	log "github.com/sirupsen/logrus"
 )
@@ -70,7 +72,11 @@ func getAllocationByCourseParticipationID(c *gin.Context) {
 
 	allocation, err := GetAllocationByCourseParticipationID(c, courseParticipationID, coursePhaseID)
 	if err != nil {
-		handleError(c, http.StatusInternalServerError, err)
+		if errors.Is(err, pgx.ErrNoRows) {
+			handleError(c, http.StatusNotFound, err)
+		} else {
+			handleError(c, http.StatusInternalServerError, err)
+		}
 		return
 	}
 

--- a/servers/team_allocation/allocation/router_test.go
+++ b/servers/team_allocation/allocation/router_test.go
@@ -108,7 +108,7 @@ func (suite *AllocationRouterTestSuite) TestGetAllocationByCourseParticipationID
 
 	suite.router.ServeHTTP(resp, req)
 
-	assert.Equal(suite.T(), http.StatusInternalServerError, resp.Code)
+	assert.Equal(suite.T(), http.StatusNotFound, resp.Code)
 }
 
 func TestAllocationRouterTestSuite(t *testing.T) {

--- a/servers/team_allocation/survey/router.go
+++ b/servers/team_allocation/survey/router.go
@@ -1,10 +1,12 @@
 package survey
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
 	"github.com/prompt-edu/prompt/servers/team_allocation/survey/surveyDTO"
 	log "github.com/sirupsen/logrus"
@@ -48,6 +50,8 @@ func getSurveyForm(c *gin.Context) {
 	if err != nil {
 		if err.Error() == "survey has not started yet" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		} else if errors.Is(err, pgx.ErrNoRows) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "survey timeframe not configured"})
 		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}

--- a/servers/team_allocation/survey/service.go
+++ b/servers/team_allocation/survey/service.go
@@ -2,12 +2,12 @@ package survey
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
@@ -31,7 +31,7 @@ func GetSurveyForm(ctx context.Context, coursePhaseID uuid.UUID) (surveyDTO.Surv
 	timeframe, err := SurveyServiceSingleton.queries.GetSurveyTimeframe(ctx, coursePhaseID)
 	if err != nil {
 		log.Error("could not get survey timeframe: ", err)
-		return surveyDTO.SurveyForm{}, errors.New("could not get survey timeframe")
+		return surveyDTO.SurveyForm{}, fmt.Errorf("could not get survey timeframe: %w", err)
 	}
 	// Ensure survey has started.
 	if time.Now().Before(timeframe.SurveyStart.Time) {
@@ -171,7 +171,7 @@ func SetSurveyTimeframe(ctx context.Context, coursePhaseID uuid.UUID, surveyStar
 
 func GetSurveyTimeframe(ctx context.Context, coursePhaseID uuid.UUID) (surveyDTO.SurveyTimeframe, error) {
 	timeframe, err := SurveyServiceSingleton.queries.GetSurveyTimeframe(ctx, coursePhaseID)
-	if err != nil && errors.Is(err, sql.ErrNoRows) {
+	if err != nil && errors.Is(err, pgx.ErrNoRows) {
 		return surveyDTO.SurveyTimeframe{TimeframeSet: false}, nil
 	} else if err != nil {
 		log.Error("could not get survey timeframe: ", err)

--- a/servers/team_allocation/team/router.go
+++ b/servers/team_allocation/team/router.go
@@ -1,10 +1,12 @@
 package teams
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
 	"github.com/prompt-edu/prompt/servers/team_allocation/team/teamDTO"
 	log "github.com/sirupsen/logrus"
@@ -83,7 +85,11 @@ func getTeamByID(c *gin.Context) {
 
 	team, err := GetTeamByID(c, coursePhaseID, teamID)
 	if err != nil {
-		handleError(c, http.StatusInternalServerError, err)
+		if errors.Is(err, pgx.ErrNoRows) {
+			handleError(c, http.StatusNotFound, err)
+		} else {
+			handleError(c, http.StatusInternalServerError, err)
+		}
 		return
 	}
 	c.JSON(http.StatusOK, team)

--- a/servers/team_allocation/team/service.go
+++ b/servers/team_allocation/team/service.go
@@ -43,7 +43,7 @@ func GetTeamByID(ctx context.Context, coursePhaseID uuid.UUID, teamID uuid.UUID)
 	})
 	if err != nil {
 		log.Error("could not get the teams from the database: ", err)
-		return promptTypes.Team{}, errors.New("could not get the teams from the database")
+		return promptTypes.Team{}, fmt.Errorf("could not get the teams from the database: %w", err)
 	}
 	return teamDTO.GetTeamDTOFromDBModel(dbTeam), nil
 }


### PR DESCRIPTION
## ✨ What is the change?

Three GET endpoints in the team-allocation service returned HTTP 500 when a row simply did not exist. They now return 404.

Affected endpoints:
- `GET /team-allocation/api/course_phase/{coursePhaseID}/survey/form` (no survey timeframe configured)
- `GET /team-allocation/api/course_phase/{coursePhaseID}/allocation/{courseParticipationID}` (participation has no allocation)
- `GET /team-allocation/api/course_phase/{coursePhaseID}/team/{teamID}` (team ID does not exist)

Two root causes fixed:
1. Service functions were wrapping `pgx.ErrNoRows` with `errors.New(...)`, discarding the sentinel so routers could not distinguish it from real DB errors.
2. `GetSurveyTimeframe` was checking `sql.ErrNoRows` instead of `pgx.ErrNoRows`; pgx v5 does not return the stdlib sentinel.

Fix: use `fmt.Errorf("...: %w", err)` in service layer to preserve the error, then branch on `errors.Is(err, pgx.ErrNoRows)` in each router handler to return 404.

## 📌 Reason for the change / Link to issue

Closes #1741. Found by the `api-stress` suite (PR #1739).

## 🧪 How to Test

```bash
cp api-stress/stress.env.example api-stress/stress.env
docker compose --env-file api-stress/stress.env \
  -f docker-compose.yml \
  -f api-stress/docker-compose.stress.yml \
  -p prompt-stress up -d
api-stress/run.sh --smoke-only
```

Open `api-stress/reports/<ts>/report.md` — the three previously failing endpoints should show 404, not 500.

Manual curl against a phase with no timeframe configured:
```bash
curl -i .../course_phase/<id>/survey/form   # expect 404
curl -i .../course_phase/<id>/allocation/<id>  # expect 404 when no allocation
curl -i .../course_phase/<id>/team/<bad-id>    # expect 404
```

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)