### PR TITLE
`General`: Improve database migration failure logs on server startup

### DIFF
--- a/servers/assessment/main.go
+++ b/servers/assessment/main.go
@@ -40,13 +40,19 @@ func getDatabaseURL() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s&TimeZone=%s", dbUser, dbPassword, dbHost, dbPort, dbName, sslMode, timeZone)
 }
 
+func sanitizeDatabaseURL(input string) string {
+	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	return strings.ReplaceAll(input, dbPassword, "***")
+}
+
 func runMigrations(databaseURL string) {
 	cmd := exec.Command("migrate", "-path", "./db/migration", "-database", databaseURL, "up")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Fatalf("Failed to run migrations: %v", err)
+	output, err := cmd.CombinedOutput()
+	sanitized := sanitizeDatabaseURL(string(output))
+	if err != nil {
+		log.Fatalf("Failed to run migrations: %v\n%s", err, sanitized)
 	}
+	fmt.Print(sanitized)
 }
 func initKeycloak(queries db.Queries) {
 	baseURL := promptSDK.GetEnv("KEYCLOAK_HOST", "http://localhost:8081")

--- a/servers/assessment/main.go
+++ b/servers/assessment/main.go
@@ -42,6 +42,9 @@ func getDatabaseURL() string {
 
 func sanitizeDatabaseURL(input string) string {
 	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	if dbPassword == "" {
+		return input
+	}
 	return strings.ReplaceAll(input, dbPassword, "***")
 }
 

--- a/servers/certificate/main.go
+++ b/servers/certificate/main.go
@@ -39,6 +39,9 @@ func getDatabaseURL() string {
 
 func sanitizeDatabaseURL(input string) string {
 	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	if dbPassword == "" {
+		return input
+	}
 	return strings.ReplaceAll(input, dbPassword, "***")
 }
 

--- a/servers/core/keycloakTokenVerifier/middleware_test.go
+++ b/servers/core/keycloakTokenVerifier/middleware_test.go
@@ -38,8 +38,7 @@ func TestLogTokenVerificationFailure(t *testing.T) {
 			entry := hook.LastEntry()
 			if entry == nil {
 				t.Fatal("expected a log entry, got none")
-			}
-			if entry.Level != tt.wantLevel {
+			} else if entry.Level != tt.wantLevel {
 				t.Fatalf("expected level %v, got %v", tt.wantLevel, entry.Level)
 			}
 		})

--- a/servers/core/main.go
+++ b/servers/core/main.go
@@ -49,6 +49,9 @@ func getDatabaseURL() string {
 
 func sanitizeDatabaseURL(input string) string {
 	dbPassword := sdkUtils.GetEnv("DB_PASSWORD", "prompt-postgres")
+	if dbPassword == "" {
+		return input
+	}
 	return strings.ReplaceAll(input, dbPassword, "***")
 }
 

--- a/servers/core/main.go
+++ b/servers/core/main.go
@@ -47,13 +47,19 @@ func getDatabaseURL() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s&TimeZone=%s", dbUser, dbPassword, dbHost, dbPort, dbName, sslMode, timeZone)
 }
 
+func sanitizeDatabaseURL(input string) string {
+	dbPassword := sdkUtils.GetEnv("DB_PASSWORD", "prompt-postgres")
+	return strings.ReplaceAll(input, dbPassword, "***")
+}
+
 func runMigrations(databaseURL string) {
 	cmd := exec.Command("migrate", "-path", "./db/migration", "-database", databaseURL, "up")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Fatalf("Failed to run migrations: %v", err)
+	output, err := cmd.CombinedOutput()
+	sanitized := sanitizeDatabaseURL(string(output))
+	if err != nil {
+		log.Fatalf("Failed to run migrations: %v\n%s", err, sanitized)
 	}
+	fmt.Print(sanitized)
 }
 
 func initKeycloak(router *gin.RouterGroup, queries db.Queries) {

--- a/servers/interview/main.go
+++ b/servers/interview/main.go
@@ -51,7 +51,9 @@ func sanitizeDatabaseURL(input string) string {
 	if dbPassword == "" {
 		return input
 	}
-	return strings.ReplaceAll(input, dbPassword, "***")
+	encoded := strings.TrimPrefix(url.UserPassword("", dbPassword).String(), ":")
+	sanitized := strings.ReplaceAll(input, dbPassword, "***")
+	return strings.ReplaceAll(sanitized, encoded, "***")
 }
 
 func runMigrations(databaseURL string) {

--- a/servers/interview/main.go
+++ b/servers/interview/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -47,13 +46,19 @@ func getDatabaseURL() string {
 	return u.String()
 }
 
+func sanitizeDatabaseURL(input string) string {
+	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	return strings.ReplaceAll(input, dbPassword, "***")
+}
+
 func runMigrations(databaseURL string) {
 	cmd := exec.Command("migrate", "-path", "./db/migration", "-database", databaseURL, "up")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Fatalf("Failed to run migrations: %v", err)
+	output, err := cmd.CombinedOutput()
+	sanitized := sanitizeDatabaseURL(string(output))
+	if err != nil {
+		log.Fatalf("Failed to run migrations: %v\n%s", err, sanitized)
 	}
+	fmt.Print(sanitized)
 }
 
 // @title           PROMPT Interview API

--- a/servers/interview/main.go
+++ b/servers/interview/main.go
@@ -48,6 +48,9 @@ func getDatabaseURL() string {
 
 func sanitizeDatabaseURL(input string) string {
 	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	if dbPassword == "" {
+		return input
+	}
 	return strings.ReplaceAll(input, dbPassword, "***")
 }
 

--- a/servers/interview/main_test.go
+++ b/servers/interview/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeDatabaseURLRedactsEscapedPassword(t *testing.T) {
+	password := "p@ss/w#rd"
+	t.Setenv("DB_PASSWORD", password)
+
+	escaped := strings.TrimPrefix(url.UserPassword("", password).String(), ":")
+	dsn := "postgres://user:" + escaped + "@localhost:5432/db"
+
+	sanitized := sanitizeDatabaseURL(dsn)
+
+	if strings.Contains(sanitized, password) {
+		t.Fatalf("raw password leaked: %s", sanitized)
+	}
+	if strings.Contains(sanitized, escaped) {
+		t.Fatalf("escaped password leaked: %s", sanitized)
+	}
+}

--- a/servers/self_team_allocation/main.go
+++ b/servers/self_team_allocation/main.go
@@ -50,13 +50,19 @@ func getDatabaseURL() string {
 // @name Authorization
 // @description Bearer token authentication. Use format: Bearer {token}
 
+func sanitizeDatabaseURL(input string) string {
+	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	return strings.ReplaceAll(input, dbPassword, "***")
+}
+
 func runMigrations(databaseURL string) {
 	cmd := exec.Command("migrate", "-path", "./db/migration", "-database", databaseURL, "up")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Fatalf("Failed to run migrations: %v", err)
+	output, err := cmd.CombinedOutput()
+	sanitized := sanitizeDatabaseURL(string(output))
+	if err != nil {
+		log.Fatalf("Failed to run migrations: %v\n%s", err, sanitized)
 	}
+	fmt.Print(sanitized)
 }
 func initKeycloak(queries db.Queries) {
 	baseURL := promptSDK.GetEnv("KEYCLOAK_HOST", "http://localhost:8081")

--- a/servers/self_team_allocation/main.go
+++ b/servers/self_team_allocation/main.go
@@ -52,6 +52,9 @@ func getDatabaseURL() string {
 
 func sanitizeDatabaseURL(input string) string {
 	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	if dbPassword == "" {
+		return input
+	}
 	return strings.ReplaceAll(input, dbPassword, "***")
 }
 

--- a/servers/team_allocation/main.go
+++ b/servers/team_allocation/main.go
@@ -51,13 +51,19 @@ func getDatabaseURL() string {
 // @name Authorization
 // @description Bearer token authentication. Use format: Bearer {token}
 
+func sanitizeDatabaseURL(input string) string {
+	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	return strings.ReplaceAll(input, dbPassword, "***")
+}
+
 func runMigrations(databaseURL string) {
 	cmd := exec.Command("migrate", "-path", "./db/migration", "-database", databaseURL, "up")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Fatalf("Failed to run migrations: %v", err)
+	output, err := cmd.CombinedOutput()
+	sanitized := sanitizeDatabaseURL(string(output))
+	if err != nil {
+		log.Fatalf("Failed to run migrations: %v\n%s", err, sanitized)
 	}
+	fmt.Print(sanitized)
 }
 func initKeycloak(queries db.Queries) {
 	baseURL := promptSDK.GetEnv("KEYCLOAK_HOST", "http://localhost:8081")

--- a/servers/team_allocation/main.go
+++ b/servers/team_allocation/main.go
@@ -53,6 +53,9 @@ func getDatabaseURL() string {
 
 func sanitizeDatabaseURL(input string) string {
 	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	if dbPassword == "" {
+		return input
+	}
 	return strings.ReplaceAll(input, dbPassword, "***")
 }
 

--- a/servers/template_server/main.go
+++ b/servers/template_server/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -34,13 +33,19 @@ func getDatabaseURL() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s&TimeZone=%s", dbUser, dbPassword, dbHost, dbPort, dbName, sslMode, timeZone)
 }
 
+func sanitizeDatabaseURL(input string) string {
+	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	return strings.ReplaceAll(input, dbPassword, "***")
+}
+
 func runMigrations(databaseURL string) {
 	cmd := exec.Command("migrate", "-path", "./db/migration", "-database", databaseURL, "up")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		log.Fatalf("Failed to run migrations: %v", err)
+	output, err := cmd.CombinedOutput()
+	sanitized := sanitizeDatabaseURL(string(output))
+	if err != nil {
+		log.Fatalf("Failed to run migrations: %v\n%s", err, sanitized)
 	}
+	fmt.Print(sanitized)
 }
 func initKeycloak(queries db.Queries) {
 	baseURL := promptSDK.GetEnv("KEYCLOAK_HOST", "http://localhost:8081")

--- a/servers/template_server/main.go
+++ b/servers/template_server/main.go
@@ -35,6 +35,9 @@ func getDatabaseURL() string {
 
 func sanitizeDatabaseURL(input string) string {
 	dbPassword := promptSDK.GetEnv("DB_PASSWORD", "prompt-postgres")
+	if dbPassword == "" {
+		return input
+	}
 	return strings.ReplaceAll(input, dbPassword, "***")
 }
 


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

When a database migration fails on server startup, the affected service now logs the actual `migrate` output (e.g. `Dirty database version N`, the failing statement) instead of only a bare `exit status 1`.

`runMigrations` in each server captures the command's combined output via `CombinedOutput`, masks the database password, and includes it in the `log.Fatalf` message. On success the output is still printed. This mirrors the pattern already used by the `certificate` server and is applied to `core`, `assessment`, `interview`, `team_allocation`, `self_team_allocation`, and `template_server`.

## 📌 Reason for the change / Link to issue

Closes #569. Previously a failed migration surfaced only `Failed to run migrations: exit status 1`, giving no indication of the real cause and making startup failures hard to diagnose.

## 🧪 How to Test

1. Point a service (e.g. `servers/core`) at a database whose migrations will fail (for example a manually set dirty state, or a hand-edited/broken migration file).
2. Start the server (`make server` for core, or run the binary directly).
3. Observe the startup log: the fatal error now includes the underlying `migrate` output, with the DB password shown as `***`.

## 🖼️ Screenshots (if UI changes are included)

<!-- No UI changes. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migration output is now sanitized before being shown or logged, preventing database passwords from appearing in server logs.
  * Failed migrations now include the cleaned output in the error message, making issues easier to diagnose without exposing secrets.
  * Empty password values are handled safely, avoiding broken redaction behavior.
* **Tests**
  * Improved a log assertion to better validate token verification failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->