### PR TITLE
`CI`: Fix dev deploy to wait and fail on all builds

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -72,7 +72,6 @@ jobs:
     needs: quality-servers
     uses: ./.github/workflows/test-servers.yml
   build-servers:
-    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'skipped') }}
     needs:
       - quality-servers
       - test-servers
@@ -86,12 +85,10 @@ jobs:
     permissions:
       contents: read
   build-clients:
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') }}
     needs: quality-clients
     uses: ./.github/workflows/build-and-push-clients.yml
     secrets: inherit
   deploy-dev:
-    if: ${{ always() && !cancelled() && !contains(needs.*.result, 'failure') }}
     needs: [build-clients, build-servers]
     uses: ./.github/workflows/deploy-docker.yml
     secrets: inherit


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Removes the custom `if:` conditions from the `build-servers`, `build-clients`, and `deploy-dev` jobs in `.github/workflows/dev.yml`. With the conditions gone, GitHub Actions falls back to its default `needs` behavior: a job runs only after all of its dependencies succeed and is skipped when any dependency fails.

## 📌 Reason for the change / Link to issue

The previous conditions (`!cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'skipped')` and the `always()`-based variants) caused `deploy-dev` to proceed even when upstream build jobs did not succeed, so a failed build did not stop the deploy. Restoring default `needs` semantics makes build and deploy correctly wait for and fail on all upstream builds.

Closes #1847.

## 🧪 How to Test

1. Push a change that makes `build-servers` or `build-clients` fail.
2. Confirm `deploy-dev` is skipped instead of running.
3. Push a passing change and confirm `build-*` and `deploy-dev` run as before.

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
