### PR TITLE
`General`: Bump version to 2.15.2 for all components

### DIFF
--- a/clients/assessment_component/package.json
+++ b/clients/assessment_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assessment_component",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/certificate_component/package.json
+++ b/clients/certificate_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certificate_component",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/core/package.json
+++ b/clients/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/interview_component/package.json
+++ b/clients/interview_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interview_component",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/matching_component/package.json
+++ b/clients/matching_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matching_component",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/package.json
+++ b/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prompt-module-federation",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "private": true,
   "workspaces": {
     "packages": [

--- a/clients/self_team_allocation_component/package.json
+++ b/clients/self_team_allocation_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self_team_allocation_component",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/team_allocation_component/package.json
+++ b/clients/team_allocation_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team_allocation_component",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/template_component/package.json
+++ b/clients/template_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "template_component",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Bumps the `version` field to `2.15.2` across all client `package.json` files (core plus every phase component) in preparation for the v2.15.2 release.

## 📌 Reason for the change / Link to issue

Version bump to cut the v2.15.2 GitHub release.

## 🧪 How to Test

1. `grep -rn '"version"' clients/**/package.json` shows `2.15.2` everywhere.
2. Clients build as before.

## 🖼️ Screenshots (if UI changes are included)

<!-- No UI changes. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
