### PR TITLE
Dependencies: Hold getsentry/sentry-go at v0.46.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,14 @@
       "description": "No minimum age for security updates",
       "matchCategories": ["security"],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Hold getsentry/sentry-go at v0.46.x — v0.47.0 removed ClientOptions.EnableLogs, still used by prompt-sdk v1.2.0. Remove once prompt-sdk supports the v0.47.0 API.",
+      "matchPackageNames": [
+        "github.com/getsentry/sentry-go",
+        "github.com/getsentry/sentry-go/**"
+      ],
+      "allowedVersions": "<0.47.0"
     }
   ]
 }


### PR DESCRIPTION
## ✨ What is the change?

Adds a Renovate `packageRule` capping the `getsentry/sentry-go` family (`sentry-go`, `sentry-go/gin`, `sentry-go/logrus`) below `v0.47.0`. Patch updates within `v0.46.x` are still allowed.

## 📌 Reason for the change / Link to issue

`sentry-go v0.47.0` is a breaking release that removes the `EnableLogs` field from `sentry.ClientOptions` (replaced by `DisableLogs`). Our `prompt-sdk v1.2.0` — the latest published version — still sets `EnableLogs: true` in `initSentry.go`, so every server that imports the SDK fails to compile under `v0.47.0`, breaking all seven `quality-server` lint jobs.

Renovate keeps re-proposing the `v0.47.0` bump and force-pushes over any manual revert on its branch, so the cap has to live in `renovate.json`. Once a `prompt-sdk` release supports the `v0.47.0` API, this rule should be removed and the upgrade allowed through.

## 🧪 How to Test

1. Validate the config: `npx --yes renovate-config-validator renovate.json` (or confirm JSON is well-formed).
2. On Renovate's next run, confirm it no longer proposes `sentry-go v0.47.0` and the "all non-major dependencies" PR no longer contains the sentry bump.

## ✅ PR Checklist

- [x] Code is clean, readable, and documented
- [ ] Tested locally or on the dev environment
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update rules to keep `sentry-go` versions below `0.47.0` for compatibility.
  * Added guidance to avoid upgrades that may break current logging-related behavior until support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->