### PR TITLE
`Core`: Fix staticcheck failure in token verifier middleware test

### DIFF
--- a/servers/core/keycloakTokenVerifier/middleware_test.go
+++ b/servers/core/keycloakTokenVerifier/middleware_test.go
@@ -38,8 +38,7 @@ func TestLogTokenVerificationFailure(t *testing.T) {
 			entry := hook.LastEntry()
 			if entry == nil {
 				t.Fatal("expected a log entry, got none")
-			}
-			if entry.Level != tt.wantLevel {
+			} else if entry.Level != tt.wantLevel {
 				t.Fatalf("expected level %v, got %v", tt.wantLevel, entry.Level)
 			}
 		})


### PR DESCRIPTION
PR #1756 landed `keycloakTokenVerifier/middleware_test.go` on `main` with a `staticcheck` SA5011 violation: after `t.Fatal` on a nil `entry`, the following `if entry.Level` block is still flagged as a possible nil dereference.

Because CI lints each PR merged with `main`, this breaks the `quality-server (core)` check on **every open PR** (e.g. #1837, #1838, #1846, #1853), not just #1756. Guarding the level check with `else` resolves it.

`golangci-lint run ./keycloakTokenVerifier/...` → 0 issues.