### PR TITLE
`Testing`: Add end-to-end coverage for the application journey

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -254,6 +254,12 @@ not from Keycloak). The `lecturer` and `course-lecturer` users hold the
 `FULL_COURSE_PHASES`, `FULL_COURSE_STUDENT`, and `FULL_COURSE_ROLES` in
 `src/data/constants.ts`.
 
+The `iPraktikumFull` Application phase is open (start 2020, end 2099, external
+students allowed) and carries one required text question (`Motivation`) so the
+application journey exercises the configurable form. `TestCourse` has a
+**closed** Application phase (`CLOSED_APPLICATION_PHASE_ID`, deadline in 2020)
+as the negative fixture for the public apply endpoints.
+
 > The course name (`iPraktikumFull`) and `semester_tag` (`ios2425`) are
 > **hyphen-free on purpose**: the course-list query parses course roles with
 > `split_part(role, '-', N)`, so a hyphen in either would break course

--- a/e2e/seed/e2e_seed.sql
+++ b/e2e/seed/e2e_seed.sql
@@ -608,6 +608,9 @@ CREATE TABLE public.student (
 -- Data for Name: application_question_text; Type: TABLE DATA; Schema: public; Owner: -
 --
 
+-- Required text question on the iPraktikumFull Application phase, so the
+-- application journey exercises the configurable form (answersText round-trip).
+INSERT INTO public.application_question_text VALUES ('ab000001-0000-0000-0000-000000000001', 'd0000001-0000-0000-0000-000000000001', 'Motivation', 'Why do you want to join this course?', 'Your motivation', '', '', true, 500, 1, false, '');
 
 
 --
@@ -740,6 +743,14 @@ INSERT INTO public.course_phase VALUES ('d0000005-0000-0000-0000-000000000005', 
 
 INSERT INTO public.course_phase VALUES ('aaaa2222-0000-0000-0000-0000000000a2', 'd7307be2-d3dc-496e-86f0-643bff6cc1c8', 'Self Team Allocation', '{}', false, 'a3333333-3333-3333-3333-333333333333', '{}');
 INSERT INTO public.course_phase VALUES ('aaaa3333-0000-0000-0000-0000000000a3', 'be780b32-a678-4b79-ae1c-80071771d254', 'Self Team Allocation', '{}', false, 'a3333333-3333-3333-3333-333333333333', '{}');
+
+--
+-- A CLOSED Application phase on TestCourse (applicationEndDate in the past):
+-- the negative fixture for the public apply endpoints (GET 404, POST 400).
+-- TestCourse has no other initial phase, so unique_initial_phase_per_course holds.
+--
+
+INSERT INTO public.course_phase VALUES ('aaaa5555-0000-0000-0000-0000000000a5', 'be780b32-a678-4b79-ae1c-80071771d254', 'Application', '{"applicationStartDate": "2020-01-01T00:00:00", "applicationEndDate": "2020-06-30T23:59:59", "externalStudentsAllowed": true, "universityLoginAvailable": false}', true, 'a1111111-1111-1111-1111-111111111111', '{}');
 
 
 --

--- a/e2e/src/data/constants.ts
+++ b/e2e/src/data/constants.ts
@@ -68,6 +68,17 @@ export const FULL_COURSE_ROLES = {
   editor: 'ios2425-iPraktikumFull-Editor',
 }
 
+// CLOSED Application phase on TestCourse (applicationEndDate in the past):
+// the public apply endpoints must reject it (GET 404, POST 400).
+export const CLOSED_APPLICATION_PHASE_ID = 'aaaa5555-0000-0000-0000-0000000000a5'
+
+// Required text question on FULL_COURSE_PHASES.application; every application
+// posted to that phase must answer it.
+export const FULL_COURSE_APPLICATION_QUESTION = {
+  id: 'ab000001-0000-0000-0000-000000000001',
+  title: 'Motivation',
+}
+
 // Self Team Allocation phase on iPraktikum (follows the Application phase).
 // The Keycloak users `student` / `student2` are enrolled participants.
 export const SELF_TEAM_ALLOCATION_PHASE_ID = 'aaaa2222-0000-0000-0000-0000000000a2'

--- a/e2e/src/pages/ApplicationAdminPage.ts
+++ b/e2e/src/pages/ApplicationAdminPage.ts
@@ -1,0 +1,44 @@
+import { Page, Locator, expect } from '@playwright/test'
+
+export type ApplicationStatusBadge = 'Not Assessed' | 'Accepted' | 'Rejected'
+
+// /management/course/:courseId/:phaseId/participants — the application phase's
+// applications table plus the per-application details page (Accept/Reject).
+export class ApplicationAdminPage {
+  constructor(private readonly page: Page) {}
+
+  async gotoParticipants(courseId: string, phaseId: string) {
+    await this.page.goto(`/management/course/${courseId}/${phaseId}/participants`)
+    await expect(
+      this.page.getByRole('heading', { name: 'Application Participants' }),
+    ).toBeVisible({ timeout: 15_000 })
+  }
+
+  applicantRow(email: string): Locator {
+    return this.page.getByRole('row').filter({ hasText: email })
+  }
+
+  async expectStatus(email: string, status: ApplicationStatusBadge) {
+    await expect(this.applicantRow(email)).toContainText(status)
+  }
+
+  async openApplication(email: string) {
+    await this.applicantRow(email).getByText(email).click()
+    await expect(this.acceptButton()).toBeVisible({ timeout: 15_000 })
+  }
+
+  async expectAnswerVisible(answer: string) {
+    await expect(this.page.getByText(answer)).toBeVisible()
+  }
+
+  // Accept flips the phase participation's pass status to 'passed'; the button
+  // disables once the updated status is reflected back into the page.
+  async accept() {
+    await this.acceptButton().click()
+    await expect(this.acceptButton()).toBeDisabled()
+  }
+
+  private acceptButton(): Locator {
+    return this.page.getByRole('button', { name: 'Accept', exact: true })
+  }
+}

--- a/e2e/src/pages/ApplyPage.ts
+++ b/e2e/src/pages/ApplyPage.ts
@@ -38,8 +38,11 @@ export class ApplyPage {
     await this.page.getByLabel(/Current Semester/).fill(applicant.currentSemester)
   }
 
+  // The question form's FormControl wraps a div (not the input itself), so the
+  // label has no control association; locate the field inside the label's item.
   async answerTextQuestion(title: string, answer: string) {
-    await this.page.getByLabel(new RegExp(title)).fill(answer)
+    const formItem = this.page.locator('label', { hasText: title }).locator('..')
+    await formItem.getByRole('textbox').fill(answer)
   }
 
   async submit() {

--- a/e2e/src/pages/ApplyPage.ts
+++ b/e2e/src/pages/ApplyPage.ts
@@ -1,0 +1,65 @@
+import { Page, expect } from '@playwright/test'
+
+export interface ApplicantData {
+  firstName: string
+  lastName: string
+  email: string
+  gender: string
+  nationality: string
+  studyDegree: string
+  studyProgram: string
+  currentSemester: string
+}
+
+// /apply/:phaseId — the public application form (no authentication). The
+// external-applicant branch is used: no matriculation/login fields.
+export class ApplyPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(phaseId: string) {
+    await this.page.goto(`/apply/${phaseId}`)
+  }
+
+  async continueAsExternal() {
+    await this.page.getByRole('button', { name: /Continue without a .*-Account/ }).click()
+    await expect(this.page.getByRole('heading', { name: 'Personal Information' })).toBeVisible()
+  }
+
+  // The shadcn Select triggers and the nationality combobox are labeled via
+  // the form's label association, so getByRole('combobox', { name }) works.
+  async fillStudentForm(applicant: ApplicantData) {
+    await this.page.getByLabel(/First Name/).fill(applicant.firstName)
+    await this.page.getByLabel(/Last Name/).fill(applicant.lastName)
+    await this.page.getByLabel(/^Email/).fill(applicant.email)
+    await this.selectOption(/Gender/, applicant.gender)
+    await this.selectNationality(applicant.nationality)
+    await this.selectOption(/Study Degree/, applicant.studyDegree)
+    await this.selectOption(/^Study Program/, applicant.studyProgram)
+    await this.page.getByLabel(/Current Semester/).fill(applicant.currentSemester)
+  }
+
+  async answerTextQuestion(title: string, answer: string) {
+    await this.page.getByLabel(new RegExp(title)).fill(answer)
+  }
+
+  async submit() {
+    await this.page.getByRole('button', { name: 'Submit' }).click()
+  }
+
+  async expectSaved() {
+    await expect(this.page.getByRole('dialog')).toContainText('Application Saved', {
+      timeout: 15_000,
+    })
+  }
+
+  private async selectOption(label: RegExp, option: string) {
+    await this.page.getByRole('combobox', { name: label }).click()
+    await this.page.getByRole('option', { name: option, exact: true }).click()
+  }
+
+  private async selectNationality(country: string) {
+    await this.page.getByRole('combobox', { name: /Nationality/ }).click()
+    await this.page.getByPlaceholder('Search nationality...').fill(country)
+    await this.page.getByRole('option', { name: country, exact: true }).click()
+  }
+}

--- a/e2e/tests/api/application-apply.api.spec.ts
+++ b/e2e/tests/api/application-apply.api.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect, request, APIRequestContext } from '@playwright/test'
+import { CORE_API_URL } from '../../src/env'
+import { apiContextFor } from '../../src/fixtures/api'
+import {
+  CLOSED_APPLICATION_PHASE_ID,
+  FULL_COURSE_APPLICATION_QUESTION,
+  FULL_COURSE_PHASES,
+} from '../../src/data/constants'
+
+const OPEN_PHASE_ID = FULL_COURSE_PHASES.application.id
+const APPLICANT_EMAIL = `e2e-api-applicant-${Date.now()}@example.com`
+
+function applicationBody(overrides: { answersText?: { applicationQuestionID: string; answer: string }[] } = {}) {
+  return {
+    student: {
+      firstName: 'Alex',
+      lastName: 'ApiApplicant',
+      email: APPLICANT_EMAIL,
+      hasUniversityAccount: false,
+      gender: 'female',
+      nationality: 'DE',
+      studyDegree: 'bachelor',
+      studyProgram: 'Computer Science',
+      currentSemester: 3,
+    },
+    answersText: overrides.answersText ?? [
+      { applicationQuestionID: FULL_COURSE_APPLICATION_QUESTION.id, answer: 'Motivated via API.' },
+    ],
+    answersMultiSelect: [],
+    answersFileUpload: [],
+  }
+}
+
+interface ApplicationParticipation {
+  courseParticipationID: string
+  passStatus: string
+  student?: { email?: string }
+}
+
+async function deleteApplication(email: string): Promise<void> {
+  const lecturer = await apiContextFor('lecturer')
+  try {
+    const res = await lecturer.get(`/api/applications/${OPEN_PHASE_ID}/participations`)
+    if (!res.ok()) return
+    const participations = (await res.json()) as ApplicationParticipation[]
+    const mine = participations.find((p) => p.student?.email === email)
+    if (!mine) return
+    await lecturer.delete(`/api/applications/${OPEN_PHASE_ID}`, {
+      data: [mine.courseParticipationID],
+    })
+  } finally {
+    await lecturer.dispose()
+  }
+}
+
+// The public /apply endpoints reject invalid submissions server-side — closed
+// phases, missing required answers, duplicate external applications.
+test.describe('core API: public application submission', () => {
+  let ctx: APIRequestContext
+
+  test.beforeAll(async () => {
+    ctx = await request.newContext({ baseURL: CORE_API_URL })
+  })
+  test.afterAll(async () => {
+    await ctx.dispose()
+    await deleteApplication(APPLICANT_EMAIL)
+  })
+
+  test('the application form of a closed phase is not served', async () => {
+    const res = await ctx.get(`/api/apply/${CLOSED_APPLICATION_PHASE_ID}`)
+    expect(res.status()).toBe(404)
+  })
+
+  test('applying to a closed phase is rejected', async () => {
+    const res = await ctx.post(`/api/apply/${CLOSED_APPLICATION_PHASE_ID}`, {
+      data: applicationBody(),
+    })
+    expect(res.status()).toBe(400)
+    expect(await res.text()).toContain('deadline')
+  })
+
+  test('an application missing a required answer is rejected', async () => {
+    const res = await ctx.post(`/api/apply/${OPEN_PHASE_ID}`, {
+      data: applicationBody({ answersText: [] }),
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('a valid application creates a participation; applying twice is rejected', async () => {
+    const created = await ctx.post(`/api/apply/${OPEN_PHASE_ID}`, { data: applicationBody() })
+    expect(created.status(), await created.text()).toBe(201)
+
+    const lecturer = await apiContextFor('lecturer')
+    try {
+      const res = await lecturer.get(`/api/applications/${OPEN_PHASE_ID}/participations`)
+      expect(res.ok(), await res.text()).toBeTruthy()
+      const participations = (await res.json()) as ApplicationParticipation[]
+      const mine = participations.find((p) => p.student?.email === APPLICANT_EMAIL)
+      expect(mine?.passStatus).toBe('not_assessed')
+    } finally {
+      await lecturer.dispose()
+    }
+
+    const duplicate = await ctx.post(`/api/apply/${OPEN_PHASE_ID}`, { data: applicationBody() })
+    expect(duplicate.status()).toBe(405)
+  })
+})

--- a/e2e/tests/application/applicant-journey.spec.ts
+++ b/e2e/tests/application/applicant-journey.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, authFile } from '../../src/fixtures/auth'
+import { apiContextFor } from '../../src/fixtures/api'
+import { ApplyPage } from '../../src/pages/ApplyPage'
+import { ApplicationAdminPage } from '../../src/pages/ApplicationAdminPage'
+import {
+  FULL_COURSE_APPLICATION_QUESTION,
+  FULL_COURSE_PHASES,
+  SEEDED_COURSES,
+} from '../../src/data/constants'
+
+const PHASE_ID = FULL_COURSE_PHASES.application.id
+const MOTIVATION_ANSWER = 'I want to build a real iOS app with a real team.'
+
+// Unique identity per run: assertions filter by it (never by row counts), so
+// parallel spec files and leftovers from crashed runs cannot collide.
+const RUN_ID = Date.now()
+const APPLICANT = {
+  firstName: 'Erika',
+  lastName: `External${RUN_ID}`,
+  email: `e2e-applicant-${RUN_ID}@example.com`,
+  gender: 'Female',
+  nationality: 'Germany',
+  studyDegree: 'Bachelor',
+  studyProgram: 'Computer Science',
+  currentSemester: '3',
+}
+
+interface ApplicationParticipation {
+  courseParticipationID: string
+  passStatus: string
+  student?: { email?: string }
+}
+
+async function findApplicationByEmail(
+  email: string,
+): Promise<ApplicationParticipation | undefined> {
+  const api = await apiContextFor('lecturer')
+  try {
+    const res = await api.get(`/api/applications/${PHASE_ID}/participations`)
+    if (!res.ok()) {
+      throw new Error(`GET participations failed: ${res.status()} ${await res.text()}`)
+    }
+    const participations = (await res.json()) as ApplicationParticipation[]
+    return participations.find((p) => p.student?.email === email)
+  } finally {
+    await api.dispose()
+  }
+}
+
+async function deleteApplicationByEmail(email: string): Promise<void> {
+  const participation = await findApplicationByEmail(email)
+  if (!participation) return
+  const api = await apiContextFor('lecturer')
+  try {
+    await api.delete(`/api/applications/${PHASE_ID}`, {
+      data: [participation.courseParticipationID],
+    })
+  } finally {
+    await api.dispose()
+  }
+}
+
+// The applicant is not logged in: the public form must work without a session.
+test.use({ storageState: { cookies: [], origins: [] } })
+
+test.describe('application: applicant journey', () => {
+  test.afterAll(async () => {
+    await deleteApplicationByEmail(APPLICANT.email)
+  })
+
+  test('an external applicant applies and the lecturer accepts them', async ({
+    page,
+    browser,
+  }) => {
+    // Applicant: public form at /apply, external branch (no university account).
+    const apply = new ApplyPage(page)
+    await apply.goto(PHASE_ID)
+    await apply.continueAsExternal()
+    await apply.fillStudentForm(APPLICANT)
+    await apply.answerTextQuestion(FULL_COURSE_APPLICATION_QUESTION.title, MOTIVATION_ANSWER)
+    await apply.submit()
+    await apply.expectSaved()
+
+    // Lecturer in their own browser context (own session/storage).
+    const lecturerContext = await browser.newContext({ storageState: authFile('lecturer') })
+    try {
+      const lecturerPage = await lecturerContext.newPage()
+      const admin = new ApplicationAdminPage(lecturerPage)
+
+      await admin.gotoParticipants(SEEDED_COURSES.fullCourse.id, PHASE_ID)
+      await admin.expectStatus(APPLICANT.email, 'Not Assessed')
+
+      await admin.openApplication(APPLICANT.email)
+      await admin.expectAnswerVisible(MOTIVATION_ANSWER)
+      await admin.accept()
+
+      await admin.gotoParticipants(SEEDED_COURSES.fullCourse.id, PHASE_ID)
+      await admin.expectStatus(APPLICANT.email, 'Accepted')
+    } finally {
+      await lecturerContext.close()
+    }
+
+    // Acceptance lands in the API: the application is passed and the applicant
+    // exists as a course participant (the participation row is created at
+    // submission; acceptance flips its pass status).
+    const accepted = await findApplicationByEmail(APPLICANT.email)
+    expect(accepted?.passStatus).toBe('passed')
+
+    const api = await apiContextFor('lecturer')
+    try {
+      const res = await api.get(`/api/courses/${SEEDED_COURSES.fullCourse.id}/participations`)
+      expect(res.ok(), await res.text()).toBeTruthy()
+      const courseParticipations = (await res.json()) as { id: string }[]
+      expect(
+        courseParticipations.some((p) => p.id === accepted?.courseParticipationID),
+      ).toBeTruthy()
+    } finally {
+      await api.dispose()
+    }
+  })
+})


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

End-to-end coverage for the full application journey. Until now the only application-flow coverage was the file-upload round-trip (`e2e/tests/api/application-files.api.spec.ts`); the form itself and everything after submission was untested.

- **UI journey** (`e2e/tests/application/applicant-journey.spec.ts`): an unauthenticated external applicant submits the public form at `/apply/:phaseId` (student fields plus a required text question), the lecturer sees the application as "Not Assessed" in the participants table, opens it, reviews the answer, and accepts it. The new status is asserted in the UI badge and via the API (`passStatus: passed` plus the corresponding course participation).
- **API-level negative checks** (`e2e/tests/api/application-apply.api.spec.ts`): the form of a closed phase is not served (404), applying to a closed phase is rejected (400), a missing required answer is rejected (400), a valid submission returns 201 and creates a `not_assessed` participation, and applying twice with the same email is rejected (405).
- **Seed**: a closed Application phase on `TestCourse` as the negative fixture, and a required `Motivation` text question on the `iPraktikumFull` Application phase so the journey exercises the configurable form (answersText round-trip), not just the student fields.
- **Page objects**: `ApplyPage` (public form incl. the select/combobox widgets) and `ApplicationAdminPage` (participants table, details, accept), plus new constants and an `e2e/README.md` test-data note.
- Both specs use unique per-run applicant identities, filter assertions by that identity, and clean up their applications via `DELETE /api/applications/:phaseId`, so spec files stay independent under parallel workers and re-runs.
- `main` is merged in; among other things this picks up the dedicated self-team-allocation overview phase, which removes a parallel-worker collision with the student-journey spec.

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

Closes #1813. Builds on the e2e infrastructure from #1810.

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. `make test-e2e` — the full Dockerized suite runs green (47 tests), including the new `tests/application/` and `tests/api/application-apply.api.spec.ts` specs
2. Optionally `make test-e2e-ui` (open http://127.0.0.1:8123) to step through the applicant journey interactively

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

No UI changes — test-only PR.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for application forms with required text questions during the public apply flow.
  * Added end-to-end coverage for submitting an application and reviewing it in the admin participant view.

* **Bug Fixes**
  * Improved handling of closed application phases so they are rejected consistently.
  * Prevented duplicate application submissions and missing required answers from being accepted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->