### PR TITLE
`Testing`: Add interview phase e2e coverage and boot it in the e2e stack

### DIFF
--- a/clients/interview_component/src/interview/pages/StudentInterview/StudentInterviewPage.tsx
+++ b/clients/interview_component/src/interview/pages/StudentInterview/StudentInterviewPage.tsx
@@ -195,6 +195,7 @@ export const StudentInterviewPage = () => {
             return (
               <Card
                 key={slot.id}
+                data-testid={`interview-slot-${slot.id}`}
                 className={cn(
                   'transition-all',
                   isBooked && 'ring-2 ring-green-500 bg-green-50 dark:bg-green-950/20',

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -81,6 +81,10 @@ services:
         condition: service_started
       client-assessment:
         condition: service_started
+      server-interview:
+        condition: service_started
+      client-interview:
+        condition: service_started
     # Adds the /self-team-allocation/* proxy locations that Traefik provides
     # in prod (client prefix stripped, API prefix kept).
     volumes:
@@ -254,6 +258,77 @@ services:
         [
           "CMD-SHELL",
           "pg_isready -d ${DB_ASSESSMENT_NAME} -U ${DB_ASSESSMENT_USER}",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ── Interview phase module (server + MF remote + own DB) ─────────────────
+  # Third phase module in the e2e stack, following the blueprint in
+  # e2e/README.md ("Phase modules in the e2e stack").
+  server-interview:
+    build:
+      context: ./servers/interview
+      dockerfile: ../Dockerfile
+    container_name: prompt-e2e-server-interview
+    depends_on:
+      db-interview:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+    # No host port: reached only through the client-core nginx proxy.
+    environment:
+      - CORE_HOST
+      - SERVER_CORE_HOST
+      - SERVER_ADDRESS
+      - SSL_MODE
+      # The service reads generic DB_USER/DB_PASSWORD/DB_NAME but
+      # service-specific host/port vars.
+      - DB_USER=${DB_INTERVIEW_USER}
+      - DB_PASSWORD=${DB_INTERVIEW_PASSWORD}
+      - DB_NAME=${DB_INTERVIEW_NAME}
+      - DB_HOST_INTERVIEW=${DB_INTERVIEW_HOST}
+      - DB_PORT_INTERVIEW=${DB_INTERVIEW_PORT}
+      - KEYCLOAK_HOST
+      - KEYCLOAK_REALM_NAME
+      - DEBUG
+    # Distroless image (no shell/wget), so no container healthcheck.
+    # Readiness is polled by the runner's global-setup via
+    # /interview/api/info through the client-core proxy.
+
+  client-interview:
+    build:
+      context: ./clients/interview_component
+      dockerfile: Dockerfile
+      args: *client-build-args
+      additional_contexts: *client-additional-contexts
+    container_name: prompt-e2e-client-interview
+    depends_on:
+      - clients-base
+    # No host port: the remote is served through the client-core nginx proxy
+    # at /interview/ (prefix stripped, like Traefik in prod).
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:80/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  db-interview:
+    image: "postgres:15.18-alpine"
+    container_name: prompt-e2e-db-interview
+    environment:
+      - POSTGRES_USER=${DB_INTERVIEW_USER}
+      - POSTGRES_PASSWORD=${DB_INTERVIEW_PASSWORD}
+      - POSTGRES_DB=${DB_INTERVIEW_NAME}
+      - TZ=Europe/Berlin
+    # No seed: the phase server runs its own migrations on the empty DB and
+    # the tests create all slots/assignments themselves.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -d ${DB_INTERVIEW_NAME} -U ${DB_INTERVIEW_USER}",
         ]
       interval: 5s
       timeout: 5s
@@ -456,6 +531,11 @@ services:
         condition: service_healthy
       server-assessment:
         # distroless; global-setup polls /assessment/api/info.
+        condition: service_started
+      client-interview:
+        condition: service_healthy
+      server-interview:
+        # distroless; global-setup polls /interview/api/info.
         condition: service_started
     environment:
       - CI

--- a/e2e/.env.e2e
+++ b/e2e/.env.e2e
@@ -66,17 +66,24 @@ DB_ASSESSMENT_NAME=prompt
 DB_ASSESSMENT_USER=prompt-postgres
 DB_ASSESSMENT_PASSWORD=prompt-postgres
 
+# ─── Interview database ──────────────────────────────────────────────────────
+DB_INTERVIEW_HOST=db-interview
+DB_INTERVIEW_PORT=5432
+DB_INTERVIEW_NAME=prompt
+DB_INTERVIEW_USER=prompt-postgres
+DB_INTERVIEW_PASSWORD=prompt-postgres
+
 # ─── Micro-frontend hosts (referenced by the core client's env.js) ──────────
 # Empty = same-origin: the component's API calls go to the browser origin
 # (client-core) and are proxied to the phase server by e2e/nginx/client-core.conf.
 SELF_TEAM_ALLOCATION_HOST=
 ASSESSMENT_HOST=
+INTERVIEW_HOST=
 # The remaining modules are not part of the e2e stack (yet).
 INTRO_COURSE_HOST=http://localhost:8082
 DEVOPS_CHALLENGE_HOST=http://localhost:9010
 TEAM_ALLOCATION_HOST=http://localhost:8083
 TEMPLATE_HOST=http://localhost:8086
-INTERVIEW_HOST=http://localhost:8087
 CERTIFICATE_HOST=http://localhost:8088
 
 # ─── S3 (SeaweedFS) ─────────────────────────────────────────────────────────

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,9 +1,9 @@
 # PROMPT 2.0 End-to-End Tests
 
 Black-box e2e tests that boot the **core server + core client + Keycloak +
-Postgres + SeaweedFS** in Docker — plus the **self team allocation** and
-**assessment phase modules** (Go service, own Postgres, Module Federation
-remote each) — and drive them like a real user, with
+Postgres + SeaweedFS** in Docker — plus the **self team allocation**,
+**assessment**, and **interview phase modules** (Go service, own Postgres,
+Module Federation remote each) — and drive them like a real user, with
 [Playwright](https://playwright.dev). They catch full-stack regressions (auth
 flow, routing, API contract, data rendering, remote loading) that the Go unit
 tests can't.
@@ -87,6 +87,11 @@ docker-compose.e2e.yml
  │    │                      migrations also create the default schemas)
  │    ├── server-assessment  built from ../servers/assessment
  │    └── client-assessment  the Module Federation remote (nginx)
+ ├── interview phase module:
+ │    ├── db-interview      own ephemeral Postgres (empty; the server runs its
+ │    │                     own migrations on startup)
+ │    ├── server-interview  built from ../servers/interview
+ │    └── client-interview  the Module Federation remote (nginx)
  └── e2e-runner    Playwright container; waits for health, runs this suite
 ```
 
@@ -108,8 +113,8 @@ to your browser - so auth behaves identically to the canonical run.
 
 The self team allocation module is the blueprint for adding a course-phase
 module (Go service + Module Federation remote) to the stack; the assessment
-module is the second implementation of it (see `tests/assessment/`). To add
-another module, copy each of these steps:
+(see `tests/assessment/`) and interview (see `tests/interview/`) modules are
+further implementations of it. To add another module, copy each of these steps:
 
 **1. Compose services** (`docker-compose.e2e.yml`): a `db-<module>` Postgres
 (ephemeral, `pg_isready` healthcheck), a `server-<module>` (build
@@ -291,10 +296,11 @@ e2e seed does not wire.
 > required DTO metadata** — fine for phase-graph, participant-list, and
 > role-access tests, but the inter-phase data-dependency graph is not exercised.
 > (`Assessment` and `Self Team Allocation` DO mirror their DTO rows, per step 3
-> of the module blueprint.) The Interview/Matching/… micro-frontend remotes are
-> also not built into the e2e client, so tests should target core-level views
-> (course config, phase graph, participant lists, role-based access), not those
-> phase remotes' own UIs.
+> of the module blueprint.) The `Interview` remote **is** now built into the e2e
+> client and exercised through its own UI (see `tests/interview/`); the
+> `Matching` / `Team Allocation` / … remotes are not, so tests for those should
+> target core-level views (course config, phase graph, participant lists,
+> role-based access), not the phase remotes' own UIs.
 
 > Note: the repo's `servers/core/database_dumps/full_db.sql` is **not** usable
 > as an e2e seed — it's a hand-maintained Go-test fixture whose schema is

--- a/e2e/nginx/client-core.conf
+++ b/e2e/nginx/client-core.conf
@@ -30,6 +30,14 @@ server {
     proxy_pass http://client-assessment/;
   }
 
+  location /interview/api/ {
+    proxy_pass http://server-interview:8080;
+  }
+
+  location /interview/ {
+    proxy_pass http://client-interview/;
+  }
+
   location / {
     gzip_static on;
     root   /usr/share/nginx/html;

--- a/e2e/seed/e2e_seed.sql
+++ b/e2e/seed/e2e_seed.sql
@@ -767,6 +767,14 @@ INSERT INTO public.course_phase VALUES ('d0000006-0000-0000-0000-000000000006', 
 INSERT INTO public.course_phase VALUES ('d0000007-0000-0000-0000-000000000007', 'c0000001-0000-0000-0000-000000000001', 'Assessment Self Evaluation', '{}', false, 'b4444444-4444-4444-4444-444444444444', '{}');
 INSERT INTO public.course_phase VALUES ('d0000008-0000-0000-0000-000000000008', 'be780b32-a678-4b79-ae1c-80071771d254', 'Assessment', '{}', false, 'b4444444-4444-4444-4444-444444444444', '{}');
 
+--
+-- Standalone interview fixture phase (no graph edge, see above):
+-- aaaa5555 = TestCourse negative-auth fixture for the interview API (no
+-- participants; the e2e users hold no TestCourse roles).
+--
+
+INSERT INTO public.course_phase VALUES ('aaaa5555-0000-0000-0000-0000000000a5', 'be780b32-a678-4b79-ae1c-80071771d254', 'Interview', '{}', false, 'b1111111-1111-1111-1111-111111111111', '{}');
+
 
 --
 -- Data for Name: course_phase_type_participation_provided_output_dto; Type: TABLE DATA; Schema: public; Owner: -

--- a/e2e/src/data/constants.ts
+++ b/e2e/src/data/constants.ts
@@ -85,6 +85,11 @@ export const ASSESSMENT_FIXTURE_PHASES = {
 // students must be rejected (negative auth fixture).
 export const ASSESSMENT_FOREIGN_PHASE_ID = 'd0000008-0000-0000-0000-000000000008'
 
+// Interview phase on TestCourse with NO participants: requests by the e2e
+// users must be rejected (negative auth fixture). The main interview phase is
+// FULL_COURSE_PHASES.interview (graph phase on fullCourse with participants).
+export const INTERVIEW_FOREIGN_PHASE_ID = 'aaaa5555-0000-0000-0000-0000000000a5'
+
 // The student mapping to the Keycloak `student` role user (Stan); participates in
 // every phase of fullCourse. Course access is DB-derived (matriculation + university
 // login), not a Keycloak role. Same student row as SEEDED_PHASE_STUDENTS.student.

--- a/e2e/src/env.ts
+++ b/e2e/src/env.ts
@@ -16,6 +16,7 @@ export const KEYCLOAK_CLIENT_ID = 'prompt-client'
 // phase server by e2e/nginx/client-core.conf, mirroring prod Traefik routing.
 export const SELF_TEAM_ALLOCATION_API = '/self-team-allocation/api'
 export const ASSESSMENT_API = '/assessment/api'
+export const INTERVIEW_API = '/interview/api'
 
 export const tokenEndpoint = () =>
   `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -4,7 +4,13 @@ import { chromium, FullConfig, request } from '@playwright/test'
 import { ROLES, SEEDED_ROLES } from './data/roles'
 import { LoginPage } from './pages/LoginPage'
 import { authFile } from './fixtures/auth'
-import { ASSESSMENT_API, BASE_URL, CORE_API_URL, SELF_TEAM_ALLOCATION_API } from './env'
+import {
+  ASSESSMENT_API,
+  BASE_URL,
+  CORE_API_URL,
+  INTERVIEW_API,
+  SELF_TEAM_ALLOCATION_API,
+} from './env'
 
 // Poll a URL until it responds (any HTTP status), or time out. The core server
 // image is distroless (no container healthcheck), so we gate readiness here.
@@ -82,6 +88,7 @@ export default async function globalSetup(_config: FullConfig) {
     'self-team-allocation',
   )
   await waitForServiceInfo(`${BASE_URL}${ASSESSMENT_API}/info`, 'assessment')
+  await waitForServiceInfo(`${BASE_URL}${INTERVIEW_API}/info`, 'interview')
 
   const browser = await chromium.launch()
   try {

--- a/e2e/src/pages/InterviewPage.ts
+++ b/e2e/src/pages/InterviewPage.ts
@@ -1,0 +1,86 @@
+import { Page, Locator, expect } from '@playwright/test'
+
+export interface SlotFormValues {
+  startTime: string // datetime-local format: YYYY-MM-DDTHH:mm
+  endTime: string
+  location: string
+  capacity: number
+}
+
+// /management/course/:courseId/:phaseId — the Interview remote (Module
+// Federation) rendered inside the core shell. The phase root shows the
+// student booking view (staff see it with a disclaimer); /schedule is the
+// lecturer-only slot management page.
+export class InterviewPage {
+  readonly heading: Locator
+
+  constructor(private readonly page: Page) {
+    this.heading = this.page.getByRole('heading', { level: 1, name: 'Interview Scheduling' })
+  }
+
+  async goto(courseId: string, phaseId: string, subpath = '') {
+    await this.page.goto(`/management/course/${courseId}/${phaseId}${subpath}`)
+  }
+
+  async expectLoaded() {
+    await expect(this.heading).toBeVisible({ timeout: 15_000 })
+  }
+
+  // ── Schedule management (lecturer) ───────────────────────────────────────
+
+  async gotoSchedule(courseId: string, phaseId: string) {
+    await this.goto(courseId, phaseId, '/schedule')
+  }
+
+  async expectScheduleLoaded() {
+    await expect(
+      this.page.getByRole('heading', { name: 'Interview Schedule Management' }),
+    ).toBeVisible({ timeout: 15_000 })
+  }
+
+  async createSlot({ startTime, endTime, location, capacity }: SlotFormValues) {
+    await this.page.getByRole('button', { name: 'Create Slot' }).click()
+    const dialog = this.page.getByRole('dialog', { name: 'Create Interview Slot' })
+    await dialog.getByLabel('Start Time').fill(startTime)
+    await dialog.getByLabel('End Time').fill(endTime)
+    await dialog.getByLabel('Location (Optional)').fill(location)
+    await dialog.getByLabel('Capacity').fill(String(capacity))
+    await dialog.getByRole('button', { name: 'Create', exact: true }).click()
+    await expect(dialog).toBeHidden()
+    await expect(this.slotRow(location)).toBeVisible()
+  }
+
+  slotRow(location: string): Locator {
+    return this.page.getByRole('row', { name: new RegExp(location) })
+  }
+
+  async assignStudent(location: string, studentName: string) {
+    await this.slotRow(location).getByRole('button', { name: 'Assign student' }).click()
+    const dialog = this.page.getByRole('dialog', { name: 'Assign Student to Interview Slot' })
+    await dialog.getByRole('combobox').click()
+    await this.page.getByRole('option', { name: studentName }).click()
+    await dialog.getByRole('button', { name: 'Assign Student' }).click()
+    await expect(dialog).toBeHidden()
+  }
+
+  // ── Student booking view (phase root) ────────────────────────────────────
+
+  slotCard(slotId: string): Locator {
+    return this.page.getByTestId(`interview-slot-${slotId}`)
+  }
+
+  // Selecting the card reveals the confirm button; booking flips the badge.
+  async bookSlot(slotId: string) {
+    const card = this.slotCard(slotId)
+    await card.click()
+    await card.getByRole('button', { name: 'Confirm Booking' }).click()
+    await expect(card.getByText('Booked', { exact: true })).toBeVisible()
+  }
+
+  async cancelBooking(slotId: string, capacity = 1) {
+    const card = this.slotCard(slotId)
+    await card.getByRole('button', { name: 'Cancel Booking' }).click()
+    await expect(card.getByText('Available', { exact: true })).toBeVisible()
+    await expect(card.getByText(`0 / ${capacity} booked`)).toBeVisible()
+  }
+}

--- a/e2e/tests/api/interview.api.spec.ts
+++ b/e2e/tests/api/interview.api.spec.ts
@@ -1,0 +1,61 @@
+import { request } from '@playwright/test'
+import { test, expect } from '../../src/fixtures/api'
+import { BASE_URL, INTERVIEW_API } from '../../src/env'
+import { FULL_COURSE_PHASES, INTERVIEW_FOREIGN_PHASE_ID } from '../../src/data/constants'
+
+// The phase server is reached on the browser origin through the e2e nginx
+// proxy (same path prefix as prod Traefik). prompt-sdk auth answers 401 both
+// for missing tokens and for valid tokens lacking the required role.
+const phaseUrl = (phaseId: string, path: string) =>
+  `${BASE_URL}${INTERVIEW_API}/course_phase/${phaseId}/${path}`
+
+const FULL_PHASE = FULL_COURSE_PHASES.interview.id
+
+test.describe('interview API auth', () => {
+  test('rejects unauthenticated requests', async () => {
+    const anon = await request.newContext()
+    try {
+      const res = await anon.get(phaseUrl(FULL_PHASE, 'interview-slots'))
+      expect(res.status()).toBe(401)
+    } finally {
+      await anon.dispose()
+    }
+  })
+
+  test('rejects a student creating a slot (staff-only endpoint)', async ({ apiAs }) => {
+    // interview-slots POST is Admin/CourseLecturer/CourseEditor only.
+    const api = await apiAs('student')
+    const res = await api.post(phaseUrl(FULL_PHASE, 'interview-slots'), { data: {} })
+    expect(res.status()).toBe(401)
+  })
+
+  test('rejects a student on the admin-assign endpoint', async ({ apiAs }) => {
+    const api = await apiAs('student')
+    const res = await api.post(phaseUrl(FULL_PHASE, 'interview-assignments/admin'), { data: {} })
+    expect(res.status()).toBe(401)
+  })
+
+  test('rejects a token without a course-scoped role', async ({ apiAs }) => {
+    // `lecturer` holds PROMPT_Lecturer only; it is CourseLecturer on fullCourse
+    // but has no role on TestCourse, which owns the foreign phase.
+    const api = await apiAs('lecturer')
+    const res = await api.post(phaseUrl(INTERVIEW_FOREIGN_PHASE_ID, 'interview-slots'), {
+      data: {},
+    })
+    expect(res.status()).toBe(401)
+  })
+
+  test('accepts an enrolled student reading slots (is_student round-trip via core)', async ({
+    apiAs,
+  }) => {
+    const api = await apiAs('student')
+    const res = await api.get(phaseUrl(FULL_PHASE, 'interview-slots'))
+    expect(res.status()).toBe(200)
+  })
+
+  test('rejects a student on a phase of a course they are not enrolled in', async ({ apiAs }) => {
+    const api = await apiAs('student')
+    const res = await api.get(phaseUrl(INTERVIEW_FOREIGN_PHASE_ID, 'interview-slots'))
+    expect(res.status()).toBe(401)
+  })
+})

--- a/e2e/tests/interview/helpers.ts
+++ b/e2e/tests/interview/helpers.ts
@@ -1,0 +1,73 @@
+import { APIRequestContext } from '@playwright/test'
+import { apiContextFor } from '../../src/fixtures/api'
+import { BASE_URL, INTERVIEW_API } from '../../src/env'
+import { FULL_COURSE_PHASES } from '../../src/data/constants'
+
+export interface InterviewSlot {
+  id: string
+  coursePhaseId: string
+  startTime: string
+  endTime: string
+  location: string | null
+  capacity: number
+  assignedCount: number
+}
+
+export function slotsUrl(phaseId = FULL_COURSE_PHASES.interview.id): string {
+  return `${BASE_URL}${INTERVIEW_API}/course_phase/${phaseId}/interview-slots`
+}
+
+// Tomorrow, so the UI treats the slot as bookable (past slots are disabled).
+export function futureSlotTimes(): { start: Date; end: Date } {
+  const start = new Date(Date.now() + 24 * 60 * 60 * 1000)
+  const end = new Date(start.getTime() + 30 * 60 * 1000)
+  return { start, end }
+}
+
+// Format for the schedule dialog's datetime-local inputs.
+export function toDatetimeLocal(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  )
+}
+
+export async function createSlot(
+  api: APIRequestContext,
+  location: string,
+  capacity = 1,
+): Promise<InterviewSlot> {
+  const { start, end } = futureSlotTimes()
+  const res = await api.post(slotsUrl(), {
+    data: {
+      startTime: start.toISOString(),
+      endTime: end.toISOString(),
+      location,
+      capacity,
+    },
+  })
+  if (!res.ok()) {
+    throw new Error(`POST slot failed: ${res.status()} ${await res.text()}`)
+  }
+  return (await res.json()) as InterviewSlot
+}
+
+// Removes test-created slots by their FIXED per-spec location (deleting a slot
+// cascades its assignments), so specs stay independent and re-runs after a
+// failure or in UI watch mode start clean. Admin passes the staff-only delete.
+export async function deleteSlotsByLocation(location: string) {
+  const admin = await apiContextFor('admin')
+  try {
+    const res = await admin.get(slotsUrl())
+    if (!res.ok()) {
+      throw new Error(`GET slots failed: ${res.status()} ${await res.text()}`)
+    }
+    const slots = (await res.json()) as InterviewSlot[]
+    for (const slot of slots.filter((s) => s.location === location)) {
+      await admin.delete(`${slotsUrl()}/${slot.id}`)
+    }
+  } finally {
+    await admin.dispose()
+  }
+}

--- a/e2e/tests/interview/lecturer-journey.spec.ts
+++ b/e2e/tests/interview/lecturer-journey.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../../src/fixtures/auth'
+import { InterviewPage } from '../../src/pages/InterviewPage'
+import { SEEDED_COURSES, FULL_COURSE_PHASES } from '../../src/data/constants'
+import { deleteSlotsByLocation, futureSlotTimes, toDatetimeLocal } from './helpers'
+
+const LOCATION = 'E2E Lecturer Slot'
+// The only uniquely-named interview participant: the phase has two distinct
+// "Niclas Heun" students, and Stan Stan is reserved for the student journey.
+const STUDENT_NAME = 'Max Mustermann'
+
+test.use({ role: 'course-lecturer' })
+
+test.describe('interview: lecturer journey', () => {
+  test.beforeAll(async () => {
+    await deleteSlotsByLocation(LOCATION)
+  })
+
+  test.afterAll(async () => {
+    await deleteSlotsByLocation(LOCATION)
+  })
+
+  test('a lecturer creates a slot and manually assigns a student', async ({ page }) => {
+    const phase = new InterviewPage(page)
+    await phase.gotoSchedule(SEEDED_COURSES.fullCourse.id, FULL_COURSE_PHASES.interview.id)
+    await phase.expectScheduleLoaded()
+
+    const { start, end } = futureSlotTimes()
+    await phase.createSlot({
+      startTime: toDatetimeLocal(start),
+      endTime: toDatetimeLocal(end),
+      location: LOCATION,
+      capacity: 1,
+    })
+
+    const row = phase.slotRow(LOCATION)
+    await expect(row.getByText('No bookings yet')).toBeVisible()
+    await expect(row.getByText('0 / 1')).toBeVisible()
+
+    await phase.assignStudent(LOCATION, STUDENT_NAME)
+
+    await expect(row.getByText(STUDENT_NAME)).toBeVisible()
+    await expect(row.getByText('1 / 1')).toBeVisible()
+    await expect(row.getByText('Full')).toBeVisible()
+  })
+})

--- a/e2e/tests/interview/mf-smoke.spec.ts
+++ b/e2e/tests/interview/mf-smoke.spec.ts
@@ -1,0 +1,17 @@
+import { test } from '../../src/fixtures/auth'
+import { InterviewPage } from '../../src/pages/InterviewPage'
+import { SEEDED_COURSES, FULL_COURSE_PHASES } from '../../src/data/constants'
+
+// Module Federation smoke test: the phase page is rendered by the
+// interview_component REMOTE, loaded by the core shell from
+// /interview/remoteEntry.js through the e2e nginx proxy. If the remote fails
+// to load, the shell renders a LoadingError instead of the heading.
+test.use({ role: 'course-lecturer' })
+
+test.describe('interview: module federation smoke', () => {
+  test('the remote loads and renders inside the core shell', async ({ page }) => {
+    const phase = new InterviewPage(page)
+    await phase.goto(SEEDED_COURSES.fullCourse.id, FULL_COURSE_PHASES.interview.id)
+    await phase.expectLoaded()
+  })
+})

--- a/e2e/tests/interview/student-journey.spec.ts
+++ b/e2e/tests/interview/student-journey.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '../../src/fixtures/auth'
+import { apiContextFor } from '../../src/fixtures/api'
+import { InterviewPage } from '../../src/pages/InterviewPage'
+import { SEEDED_COURSES, FULL_COURSE_PHASES } from '../../src/data/constants'
+import { createSlot, deleteSlotsByLocation } from './helpers'
+
+const LOCATION = 'E2E Student Slot'
+
+test.use({ role: 'student' })
+
+test.describe('interview: student journey', () => {
+  let slotId: string
+
+  test.beforeAll(async () => {
+    await deleteSlotsByLocation(LOCATION)
+    const admin = await apiContextFor('admin')
+    try {
+      const slot = await createSlot(admin, LOCATION, 1)
+      slotId = slot.id
+    } finally {
+      await admin.dispose()
+    }
+  })
+
+  test.afterAll(async () => {
+    await deleteSlotsByLocation(LOCATION)
+  })
+
+  test('a student books a slot and then cancels the booking', async ({ page }) => {
+    const phase = new InterviewPage(page)
+    await phase.goto(SEEDED_COURSES.fullCourse.id, FULL_COURSE_PHASES.interview.id)
+    await phase.expectLoaded()
+
+    await phase.bookSlot(slotId)
+    await expect(phase.slotCard(slotId).getByText('1 / 1 booked')).toBeVisible()
+
+    await phase.cancelBooking(slotId)
+  })
+})


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Adds e2e coverage for the interview phase module and boots it into the Dockerized e2e stack, following the phase-module blueprint documented in `e2e/README.md` (same pattern as self team allocation and assessment).

- **Stack wiring** (`docker-compose.e2e.yml`, `e2e/.env.e2e`, `e2e/nginx/client-core.conf`): adds `db-interview`, `server-interview`, and `client-interview` services, proxies `/interview/api/` (prefix kept) to the Go service and `/interview/` (prefix stripped) to the Module Federation remote, and serves the component same-origin (`INTERVIEW_HOST=`).
- **Readiness gate** (`e2e/src/env.ts`, `e2e/src/global-setup.ts`): global-setup now polls `/interview/api/info` through the client-core proxy before any spec runs.
- **Seed** (`e2e/seed/e2e_seed.sql`, `e2e/src/data/constants.ts`): one data-only INSERT for a foreign Interview phase on `TestCourse` (`aaaa5555-…`) used by the negative-auth checks. The main phase and its participants already exist from a prior seed change; `schema_migrations` is unchanged.
- **Client** (`StudentInterviewPage.tsx`): adds a `data-testid` to the slot card so the student journey can address a specific slot.
- **Specs** (`e2e/src/pages/InterviewPage.ts`, `e2e/tests/interview/`, `e2e/tests/api/interview.api.spec.ts`): a page object, helpers, an MF smoke test, lecturer and student journeys, and an API auth spec.
- **Docs** (`e2e/README.md`): lists the interview module in the stack diagram/intro and softens the "remotes not built into the e2e client" note.

## 📌 Reason for the change / Link to issue

The interview service (`servers/interview`) and client (`clients/interview_component`) had no e2e coverage and were not part of the e2e stack. This closes that gap by exercising the lecturer slot-management flow, the student self-book/cancel flow, and the API auth contract end-to-end.

## 🧪 How to Test

1. `make test-e2e` — full Dockerized stack boots (global-setup now gates on `/interview/api/info`) and all specs pass, including the existing suites.
2. Subset while iterating:
   `docker compose -f docker-compose.e2e.yml --env-file e2e/.env.e2e run --rm e2e-runner npx playwright test tests/interview tests/api/interview.api.spec.ts`
   then `make test-e2e-down`.
3. `make lint`.

Verified locally: `make test-e2e` → 51 passed (9 new interview tests plus all pre-existing suites), no regressions.

## 🖼️ Screenshots (if UI changes are included)

No user-facing UI changes (only a non-visual `data-testid` attribute).

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interview phase support to the end-to-end environment, including routing, service startup checks, and dedicated test data.
  * Introduced interview-focused Playwright coverage for API access, lecturer journeys, student booking/cancellation, and module loading.
  * Added reusable interview page-object and API helpers for creating, booking, canceling, and cleaning up interview slots.
* **Bug Fixes**
  * Improved UI test targeting with a stable identifier on interview slot cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->