### PR TITLE
`Testing`: Add browser e2e test for application file upload/download

### DIFF
--- a/e2e/seed/e2e_seed.sql
+++ b/e2e/seed/e2e_seed.sql
@@ -596,6 +596,7 @@ CREATE TABLE public.student (
 -- Data for Name: application_question_file_upload; Type: TABLE DATA; Schema: public; Owner: -
 --
 
+INSERT INTO public.application_question_file_upload VALUES ('bbbb0001-0000-0000-0000-0000000000b1', 'aaaa1111-0000-0000-0000-0000000000a1', 'Upload your CV', 'Attach your CV.', false, '.txt,.pdf', 50, 0, false, NULL);
 
 
 --
@@ -726,9 +727,11 @@ INSERT INTO public.course_phase_type VALUES ('b4444444-4444-4444-4444-4444444444
 --
 -- An open Application phase on iPraktikum, so the file-upload endpoints accept
 -- uploads (applicationEndDate in the future → CheckIfCoursePhaseIsOpenApplicationPhase passes).
+-- applicationStartDate + explicit externalStudentsAllowed are required by the stricter
+-- GetOpenApplicationPhase query that backs the public /apply form (start<NOW; non-null bool casts).
 --
 
-INSERT INTO public.course_phase VALUES ('aaaa1111-0000-0000-0000-0000000000a1', 'd7307be2-d3dc-496e-86f0-643bff6cc1c8', 'Application', '{"applicationEndDate": "2099-12-31T23:59:59", "universityLoginAvailable": false}', true, 'a1111111-1111-1111-1111-111111111111', '{}');
+INSERT INTO public.course_phase VALUES ('aaaa1111-0000-0000-0000-0000000000a1', 'd7307be2-d3dc-496e-86f0-643bff6cc1c8', 'Application', '{"applicationStartDate": "2020-01-01T00:00:00", "applicationEndDate": "2099-12-31T23:59:59", "externalStudentsAllowed": false, "universityLoginAvailable": false}', true, 'a1111111-1111-1111-1111-111111111111', '{}');
 
 --
 -- A Self Team Allocation phase on iPraktikum (follows Application in the

--- a/e2e/src/pages/ApplicationFormPage.ts
+++ b/e2e/src/pages/ApplicationFormPage.ts
@@ -1,0 +1,34 @@
+import { type Page, type Locator, expect } from '@playwright/test'
+
+// The public applicant application form at /apply/:phaseId. With
+// universityLoginAvailable=false the login card offers a single "Continue as
+// ... student" button that leads straight to the form (no Keycloak).
+export class ApplicationFormPage {
+  readonly fileInput: Locator
+
+  constructor(private readonly page: Page) {
+    this.fileInput = page.locator('input[type="file"]')
+  }
+
+  async goto(phaseId: string) {
+    await this.page.goto(`/apply/${phaseId}`)
+  }
+
+  async continueToForm() {
+    await this.page.getByRole('button', { name: /continue as .* student/i }).click()
+    await expect(
+      this.page.getByRole('heading', { name: /course specific questions/i }),
+    ).toBeVisible()
+  }
+
+  // The FileUpload widget uploads immediately on selection (presign -> PUT ->
+  // complete), so this is the whole upload action; no form submit needed.
+  async uploadFile(name: string, buffer: Buffer, mimeType = 'text/plain') {
+    await this.fileInput.setInputFiles({ name, mimeType, buffer })
+  }
+
+  async expectFileListed(name: string) {
+    await expect(this.page.getByText('Uploaded file:')).toBeVisible()
+    await expect(this.page.getByText(name)).toBeVisible()
+  }
+}

--- a/e2e/tests/application/file-upload.spec.ts
+++ b/e2e/tests/application/file-upload.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { ApplicationFormPage } from '../../src/pages/ApplicationFormPage'
+import { OPEN_APPLICATION_PHASE_ID } from '../../src/data/constants'
+
+// Browser counterpart to tests/api/application-files.api.spec.ts: drives the
+// real applicant FileUpload widget so the client's own presign -> PUT-to-S3 ->
+// complete calls (from @tumaet/prompt-ui-components) get exercised, not
+// hand-crafted HTTP. The public /apply page needs no login.
+test.describe('application file upload (browser)', () => {
+  test('an applicant uploads a file and it round-trips through S3', async ({ page }) => {
+    const body = Buffer.from('e2e browser upload')
+    const appForm = new ApplicationFormPage(page)
+
+    await appForm.goto(OPEN_APPLICATION_PHASE_ID)
+    await appForm.continueToForm()
+
+    // Arm before selecting the file: the widget uploads on selection.
+    const completePromise = page.waitForResponse(
+      (r) => r.url().includes('/files/complete') && r.request().method() === 'POST',
+    )
+    await appForm.uploadFile('cv.txt', body)
+
+    const complete = await completePromise
+    expect(complete.status(), await complete.text()).toBe(201)
+    await appForm.expectFileListed('cv.txt')
+
+    // Presigned download TTL is ~30s, so fetch immediately.
+    const { downloadUrl } = (await complete.json()) as { downloadUrl: string }
+    expect(downloadUrl).toBeTruthy()
+    const download = await page.request.get(downloadUrl)
+    expect(download.ok(), `download failed: ${download.status()}`).toBeTruthy()
+    expect(await download.body()).toEqual(body)
+  })
+})


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

<!-- Briefly describe what has been changed or added in this PR. -->

Adds a browser (Chromium) Playwright e2e test for the application file upload/download flow, driving the real applicant `FileUpload` widget on the public `/apply/:phaseId` form. The test uploads a file, asserts it appears in the applicant's file list, and verifies the uploaded bytes round-trip back through the presigned download URL the UI received. This complements the existing API-layer spec (`e2e/tests/api/application-files.api.spec.ts`) by exercising the client's own presign/PUT/complete path rather than hand-crafted HTTP.

- `e2e/tests/application/file-upload.spec.ts` — new spec.
- `e2e/src/pages/ApplicationFormPage.ts` — new Page Object (`goto`, `continueToForm`, `uploadFile`, `expectFileListed`).
- `e2e/seed/e2e_seed.sql` — seeds one `application_question_file_upload` question on the open Application phase so the widget renders, and opens that phase to the stricter `GetOpenApplicationPhase` query that backs the public form (adds `applicationStartDate` and an explicit `externalStudentsAllowed`; the file endpoints alone only needed `applicationEndDate`).

## 📌 Reason for the change / Link to issue

<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->

Closes #1585. The suite already covered the storage round-trip at the API layer, but nothing exercised the actual browser upload/download path through the shared `FileUpload`/`FileList` components. This closes that gap in the dominant browser-journey style used by the rest of the suite.

## 🧪 How to Test

<!-- List the steps someone should follow to test this PR. -->

1. `make test-e2e` (builds the Docker stack + runs the full suite; teardown with `make test-e2e-down`).
2. Or run just the new spec against a built stack: `docker compose -f docker-compose.e2e.yml --env-file e2e/.env.e2e run --rm e2e-runner npx playwright test tests/application`.
3. Confirm `tests/application/file-upload.spec.ts` passes and the existing `tests/api/application-files.api.spec.ts` still passes. Full local run: **43 passed**.

Note: run inside the Docker runner — the presigned `downloadUrl` embeds the `seaweedfs-s3` service hostname, which only resolves inside the compose network.

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

N/A — test-only change, no UI changes.

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading files in the application form flow.
  * Improved the application form experience with clearer file-upload handling and download verification.

* **Bug Fixes**
  * Updated application phase data so opening rules now reflect the correct start date and external-student availability.
  * Added additional seeded application-upload data to better match real application scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->