### PR TITLE
`Assessment`: Add prev/next navigation between tutors

### DIFF
--- a/clients/assessment_component/src/assessment/pages/TutorEvaluationResultsPage/TutorEvaluationResultsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/TutorEvaluationResultsPage/TutorEvaluationResultsPage.tsx
@@ -1,7 +1,13 @@
-import { Card, CardContent, ErrorPage, ManagementPageHeader } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
+import {
+  Button,
+  Card,
+  CardContent,
+  ErrorPage,
+  ManagementPageHeader,
+} from '@tumaet/prompt-ui-components'
+import { ChevronLeft, ChevronRight, Loader2 } from 'lucide-react'
 import { useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { AssessmentType } from '../../interfaces/assessmentType'
 import { FeedbackItemDisplayPanel } from '../components/FeedbackItemDisplayPanel/FeedbackItemDisplayPanel'
 import { useGetAllTeams } from '../hooks/useGetAllTeams'
@@ -10,9 +16,12 @@ import { useGetEvaluationCategoriesWithCompetencies } from '../hooks/useGetEvalu
 import { CategoryEvaluation } from './components/CategoryEvaluation'
 import { useGetEvaluationsForTutorInPhase } from './hooks/useGetEvaluationsForTutorInPhase'
 import { useGetFeedbackItemsForTutorInPhase } from './hooks/useGetFeedbackItemsForTutorInPhase'
+import { useTutorNavigation } from './hooks/useTutorNavigation'
 
 export const TutorEvaluationResultsPage = () => {
   const { tutorId } = useParams<{ tutorId: string }>()
+  const navigate = useNavigate()
+  const { prevTutor, nextTutor } = useTutorNavigation()
 
   const { data: coursePhaseConfig } = useGetCoursePhaseConfig()
   const { data: teams } = useGetAllTeams()
@@ -83,9 +92,41 @@ export const TutorEvaluationResultsPage = () => {
 
   return (
     <div className='space-y-4'>
-      <ManagementPageHeader>
-        Tutor Evaluation Results for {tutor.firstName} {tutor.lastName}
-      </ManagementPageHeader>
+      <div className='flex items-center gap-2 [&_h1]:mb-0'>
+        {prevTutor && (
+          <Button
+            variant='outline'
+            className='h-10 shrink-0'
+            aria-label={`Navigate to previous tutor: ${prevTutor.firstName} ${prevTutor.lastName}`}
+            onClick={() => navigate(`../${prevTutor.id}`, { relative: 'path' })}
+          >
+            <ChevronLeft className='h-4 w-4' />
+            <span className='hidden md:inline'>
+              {prevTutor.firstName} {prevTutor.lastName}
+            </span>
+          </Button>
+        )}
+
+        <div className='min-w-0 flex-1'>
+          <ManagementPageHeader>
+            Tutor Evaluation Results for {tutor.firstName} {tutor.lastName}
+          </ManagementPageHeader>
+        </div>
+
+        {nextTutor && (
+          <Button
+            variant='outline'
+            className='h-10 shrink-0'
+            aria-label={`Navigate to next tutor: ${nextTutor.firstName} ${nextTutor.lastName}`}
+            onClick={() => navigate(`../${nextTutor.id}`, { relative: 'path' })}
+          >
+            <span className='hidden md:inline'>
+              {nextTutor.firstName} {nextTutor.lastName}
+            </span>
+            <ChevronRight className='h-4 w-4' />
+          </Button>
+        )}
+      </div>
 
       {tutorEvaluationCategories.length === 0 ? (
         <Card>

--- a/clients/assessment_component/src/assessment/pages/TutorEvaluationResultsPage/hooks/useTutorNavigation.ts
+++ b/clients/assessment_component/src/assessment/pages/TutorEvaluationResultsPage/hooks/useTutorNavigation.ts
@@ -1,0 +1,48 @@
+import { useMemo } from 'react'
+import { useParams } from 'react-router-dom'
+import { useGetAllTeams } from '../../hooks/useGetAllTeams'
+
+interface NavigationTutor {
+  id: string
+  firstName: string
+  lastName: string
+}
+
+interface TutorNavigation {
+  prevTutor?: NavigationTutor
+  nextTutor?: NavigationTutor
+}
+
+/**
+ * Resolves the previous and next tutor relative to the one currently in the
+ * URL. Unlike participant navigation, this always cycles through every tutor
+ * across all teams.
+ */
+export const useTutorNavigation = (): TutorNavigation => {
+  const { tutorId } = useParams<{ tutorId: string }>()
+  const { data: teams } = useGetAllTeams()
+
+  const tutors = useMemo<NavigationTutor[]>(() => {
+    const seen = new Set<string>()
+    const result: NavigationTutor[] = []
+    for (const team of teams) {
+      for (const tutor of team.tutors) {
+        if (!tutor.id || seen.has(tutor.id)) continue
+        seen.add(tutor.id)
+        result.push({ id: tutor.id, firstName: tutor.firstName, lastName: tutor.lastName })
+      }
+    }
+    return result
+  }, [teams])
+
+  const currentIndex = tutors.findIndex((tutor) => tutor.id === tutorId)
+
+  if (currentIndex === -1 || tutors.length <= 1) {
+    return {}
+  }
+
+  return {
+    prevTutor: tutors[(currentIndex - 1 + tutors.length) % tutors.length],
+    nextTutor: tutors[(currentIndex + 1) % tutors.length],
+  }
+}


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Adds previous/next navigation buttons to the tutor evaluation results page
(`/tutors/:tutorId`), styled like the prev/next buttons on the assessment page.
The buttons flank the page header and show the adjacent tutor's name (name hidden
on small screens). A new `useTutorNavigation` hook resolves the neighbours by
cycling through **all** tutors across every team (deduplicated by id), rather than
scoping navigation to a single team like the participant navigation does. Buttons
only render when more than one tutor exists.

## 📌 Reason for the change / Link to issue

Reviewing tutors one by one previously required returning to the Tutor Overview
table between each tutor. This lets a lecturer page through every tutor's
evaluation results directly. Closes #1871.

## 🧪 How to Test

1. Open an assessment phase as a lecturer and go to **Tutor Overview**.
2. Click a tutor to open their evaluation results (`/tutors/:tutorId`).
3. Use the **previous** / **next** buttons beside the header to move between
   tutors; navigation wraps around and covers all tutors across teams.

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [ ] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
