### PR TITLE
`Testing`: Add role and permission matrix e2e coverage

### DIFF
--- a/e2e/src/data/permissionMatrix.ts
+++ b/e2e/src/data/permissionMatrix.ts
@@ -1,0 +1,151 @@
+// Data-driven role x surface authorization matrix. Adding a surface is one entry
+// in SURFACES; the browser and API specs both derive their cases from it.
+//
+// Authorization model (servers/core/permissionValidation): denials return 403,
+// missing/invalid token returns 401, and there is no implicit admin bypass -
+// admin only passes where PromptAdmin is an explicitly allowed role. The frontend
+// PermissionRestriction renders the shared UnauthorizedPage ("Access Denied") when
+// the current role lacks the route's permissions for the current course.
+
+import { Role } from './roles'
+import {
+  SEEDED_COURSES,
+  SELF_TEAM_ALLOCATION_PHASE_ID,
+  FULL_COURSE_PHASES,
+} from './constants'
+
+// The five task roles (student2 is an extra journey user, not part of the matrix).
+export const MATRIX_ROLES: Role[] = [
+  'admin',
+  'lecturer',
+  'course-lecturer',
+  'course-editor',
+  'student',
+]
+
+// Course that holds every course-scoped role in the seed, so allowed cases resolve.
+export const PRIMARY_COURSE = SEEDED_COURSES.fullCourse
+
+// fullCourse's Application phase (mailing) and an iPraktikum phase the student is
+// enrolled in (student self-participation).
+const MAILING_PHASE_ID = FULL_COURSE_PHASES.application.id
+const STUDENT_PHASE_ID = SELF_TEAM_ALLOCATION_PHASE_ID
+
+export interface Surface {
+  name: string
+  browser?: {
+    path: (courseId: string) => string
+    heading: string // the page <h1> rendered when authorized
+    allowed: Role[]
+  }
+  api?: {
+    method?: 'GET' | 'PUT' // default GET
+    path: (courseId: string) => string
+    allowed: Role[]
+    allowedStatus?: number // default: any 2xx; mailing probe -> 400
+    invalidBody?: string // malformed body for the allowed-side probe (mailing)
+    blockedReason?: string // appended to blocked test titles for clarity
+  }
+}
+
+export const SURFACES: Surface[] = [
+  {
+    name: 'courses list',
+    browser: {
+      path: () => '/management/courses',
+      heading: 'Courses',
+      allowed: ['admin', 'lecturer', 'course-lecturer', 'course-editor', 'student'],
+    },
+    api: {
+      path: () => '/api/courses/',
+      allowed: ['admin', 'lecturer', 'course-lecturer', 'course-editor', 'student'],
+    },
+  },
+  {
+    name: 'student list',
+    browser: {
+      path: () => '/management/students',
+      heading: 'Students',
+      allowed: ['admin', 'lecturer'],
+    },
+    api: {
+      path: () => '/api/students/',
+      allowed: ['admin', 'lecturer'],
+    },
+  },
+  {
+    name: 'course settings',
+    browser: {
+      path: (courseId) => `/management/course/${courseId}/settings`,
+      heading: 'Settings',
+      allowed: ['admin', 'lecturer', 'course-lecturer'],
+    },
+  },
+  {
+    // API read of course data - editors may read it even though they cannot open
+    // the Settings page (page guard is Admin+Lecturer, API read also allows Editor).
+    name: 'course detail',
+    api: {
+      path: (courseId) => `/api/courses/${courseId}`,
+      allowed: ['admin', 'lecturer', 'course-lecturer', 'course-editor'],
+    },
+  },
+  {
+    name: 'phase config',
+    browser: {
+      path: (courseId) => `/management/course/${courseId}/configurator`,
+      heading: 'Course Configurator',
+      allowed: ['admin', 'lecturer', 'course-lecturer', 'course-editor'],
+    },
+    api: {
+      path: (courseId) => `/api/courses/${courseId}/phase_graph`,
+      allowed: ['admin', 'lecturer', 'course-lecturer', 'course-editor'],
+    },
+  },
+  {
+    name: 'mailing',
+    browser: {
+      path: (courseId) => `/management/course/${courseId}/${MAILING_PHASE_ID}/mailing`,
+      heading: 'Application Mailing Settings',
+      allowed: ['admin', 'lecturer', 'course-lecturer'],
+    },
+    api: {
+      // A malformed body proves auth passed (400 after BindJSON) without sending
+      // mail; blocked roles never reach BindJSON (403 in the middleware first).
+      method: 'PUT',
+      path: () => `/api/mailing/${MAILING_PHASE_ID}`,
+      allowed: ['admin', 'lecturer', 'course-lecturer'],
+      allowedStatus: 400,
+      invalidBody: 'not-json',
+    },
+  },
+  {
+    name: 'student self-participation',
+    api: {
+      path: () => `/api/course_phases/${STUDENT_PHASE_ID}/participations/self`,
+      allowed: ['student'],
+      blockedReason: 'no implicit admin bypass',
+    },
+  },
+]
+
+// A role scoped to PRIMARY_COURSE must be denied on courses it has no role in.
+// Only surfaces the role is *allowed* on for PRIMARY_COURSE are listed, so each
+// case is a genuine isolation signal rather than a blanket denial.
+//
+// Caveat: keep cross-course surfaces to DIRECT guarded routes (course settings /
+// phase config). Phase routes (`/:courseId/:phaseId/*`) resolve the phase through
+// PhaseRouterMapping first and render "Phase not found" for an inaccessible course
+// before PermissionRestriction runs - so a phase/mailing cross-course row would
+// need a different assertion.
+export interface CrossCourseCase {
+  role: Role
+  course: { id: string; name: string }
+  surfaces: string[]
+}
+
+export const CROSS_COURSE: CrossCourseCase[] = [
+  { role: 'course-editor', course: SEEDED_COURSES.iPraktikum, surfaces: ['phase config'] },
+  { role: 'course-editor', course: SEEDED_COURSES.testCourse, surfaces: ['course detail', 'phase config'] },
+  { role: 'course-lecturer', course: SEEDED_COURSES.testCourse, surfaces: ['course settings', 'course detail'] },
+]

--- a/e2e/tests/permissions/browser-matrix.spec.ts
+++ b/e2e/tests/permissions/browser-matrix.spec.ts
@@ -1,0 +1,60 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from '../../src/fixtures/auth'
+import {
+  MATRIX_ROLES,
+  PRIMARY_COURSE,
+  SURFACES,
+  CROSS_COURSE,
+} from '../../src/data/permissionMatrix'
+
+const browserSurfaces = SURFACES.filter((s) => s.browser)
+
+async function expectAllowed(page: Page, heading: string) {
+  await expect(page.getByRole('heading', { level: 1, name: heading })).toBeVisible()
+}
+
+// Blocked pages render UnauthorizedPage ("Access Denied"). Asserting that overlay
+// (not just the missing heading) rules out a false pass from a slow load, a wrong
+// route, or a crash.
+async function expectBlocked(page: Page, heading: string) {
+  await expect(page.getByText('Access Denied')).toBeVisible()
+  await expect(page.getByRole('heading', { level: 1, name: heading })).toBeHidden()
+}
+
+test.describe('permission matrix (browser)', () => {
+  for (const role of MATRIX_ROLES) {
+    test.describe(role, () => {
+      test.use({ role })
+
+      for (const surface of browserSurfaces) {
+        const browser = surface.browser!
+        const allowed = browser.allowed.includes(role)
+
+        test(`${allowed ? 'sees' : 'is blocked from'} ${surface.name}`, async ({ page }) => {
+          await page.goto(browser.path(PRIMARY_COURSE.id))
+          if (allowed) await expectAllowed(page, browser.heading)
+          else await expectBlocked(page, browser.heading)
+        })
+      }
+    })
+  }
+})
+
+test.describe('cross-course isolation (browser)', () => {
+  for (const testCase of CROSS_COURSE) {
+    test.describe(`${testCase.role} cannot reach ${testCase.course.name}`, () => {
+      test.use({ role: testCase.role })
+
+      for (const surfaceName of testCase.surfaces) {
+        const surface = SURFACES.find((s) => s.name === surfaceName)
+        if (!surface?.browser) continue
+        const browser = surface.browser
+
+        test(`is blocked from ${surfaceName}`, async ({ page }) => {
+          await page.goto(browser.path(testCase.course.id))
+          await expectBlocked(page, browser.heading)
+        })
+      }
+    })
+  }
+})

--- a/e2e/tests/permissions/permission-matrix.api.spec.ts
+++ b/e2e/tests/permissions/permission-matrix.api.spec.ts
@@ -1,0 +1,79 @@
+import { request } from '@playwright/test'
+import type { APIRequestContext } from '@playwright/test'
+import { test, expect } from '../../src/fixtures/api'
+import { CORE_API_URL } from '../../src/env'
+import {
+  MATRIX_ROLES,
+  PRIMARY_COURSE,
+  SURFACES,
+  CROSS_COURSE,
+  Surface,
+} from '../../src/data/permissionMatrix'
+
+const apiSurfaces = SURFACES.filter((s) => s.api)
+
+function callSurface(api: APIRequestContext, surface: Surface, courseId: string) {
+  const a = surface.api!
+  const url = a.path(courseId)
+  if (a.method === 'PUT') {
+    return api.put(url, {
+      headers: { 'content-type': 'application/json' },
+      data: a.invalidBody ?? '',
+    })
+  }
+  return api.get(url)
+}
+
+test.describe('permission matrix (API)', () => {
+  for (const surface of apiSurfaces) {
+    const a = surface.api!
+
+    for (const role of MATRIX_ROLES) {
+      const allowed = a.allowed.includes(role)
+      const title = allowed
+        ? `${role} may access ${surface.name}`
+        : `${role} is blocked from ${surface.name} (403${
+            a.blockedReason ? `, ${a.blockedReason}` : ''
+          })`
+
+      test(title, async ({ apiAs }) => {
+        const api = await apiAs(role)
+        const res = await callSurface(api, surface, PRIMARY_COURSE.id)
+        if (allowed) {
+          if (a.allowedStatus) expect(res.status()).toBe(a.allowedStatus)
+          else expect(res.ok()).toBeTruthy()
+        } else {
+          expect(res.status()).toBe(403)
+        }
+      })
+    }
+  }
+})
+
+test.describe('unauthenticated requests are rejected (401)', () => {
+  for (const surface of apiSurfaces) {
+    test(`${surface.name} requires a token`, async () => {
+      const anon = await request.newContext({ baseURL: CORE_API_URL })
+      const res = await callSurface(anon, surface, PRIMARY_COURSE.id)
+      expect(res.status()).toBe(401)
+      await anon.dispose()
+    })
+  }
+})
+
+test.describe('cross-course isolation (API)', () => {
+  for (const testCase of CROSS_COURSE) {
+    for (const surfaceName of testCase.surfaces) {
+      const surface = SURFACES.find((s) => s.name === surfaceName)
+      if (!surface?.api) continue
+
+      test(`${testCase.role} is blocked from ${surfaceName} on ${testCase.course.name} (403)`, async ({
+        apiAs,
+      }) => {
+        const api = await apiAs(testCase.role)
+        const res = await callSurface(api, surface, testCase.course.id)
+        expect(res.status()).toBe(403)
+      })
+    }
+  }
+})


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Adds one data-driven authorization matrix e2e suite covering every seeded role against the key surfaces, at both the browser and API layers.

- `e2e/src/data/permissionMatrix.ts` holds a single `SURFACES` table (role x surface, each entry with an optional `browser` and/or `api` block) plus a `CROSS_COURSE` list. Adding a surface is one object; both specs derive their cases from it.
- `e2e/tests/permissions/browser-matrix.spec.ts` (chromium project) asserts, for each role, allowed vs blocked on the courses list, student list, course settings, phase configuration, and mailing pages. Blocked pages assert the `UnauthorizedPage` "Access Denied" marker (not just a missing heading) so a slow load or crash cannot false-pass.
- `e2e/tests/permissions/permission-matrix.api.spec.ts` (api project) asserts `200`/`403` per role on the corresponding core endpoints, `401` for unauthenticated requests, and cross-course denials.

Coverage highlights:
- Every seeded role gets at least one allowed and one blocked case. Because there is no implicit admin bypass in the core role check, `admin`/`lecturer` are blocked at the student-only self-participation endpoint, and those test titles say so explicitly.
- Course-scoped isolation: `course-editor` (role only in `iPraktikumFull`) and `course-lecturer` are denied on courses they hold no role in, at both layers.
- Mailing authorization is proven without sending mail: an intentionally malformed body makes allowed roles return `400` (auth passed, rejected before send) while blocked roles get `403` in the middleware first.

No production code, seed, or realm changes.

## 📌 Reason for the change / Link to issue

Closes #1814.

Authorization is the class of bug this platform is most exposed to, yet the e2e suite pre-authenticated all five roles but exercised only `admin` and `student`, with a single access-control check (student blocked from the student list). This suite turns that into systematic role x surface coverage. It builds on the realistic course-scoped seed from #1810 (already merged), which provides the second course and course-scoped role holders needed for cross-course isolation.

## 🧪 How to Test

1. Boot the stack and run the suite: `make test-e2e` (CI-identical), or boot once and iterate with `cd e2e && npx playwright test tests/permissions`.
2. Confirm all matrix tests pass (68 total: 40 API + 28 browser).
3. Optional: `cd e2e && npm run typecheck` for type safety (the suite is `any`-free).

Verified locally against the Dockerized e2e stack: `68 passed`.

## 🖼️ Screenshots (if UI changes are included)

N/A - test-only change, no UI changes.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader permission coverage for browser and API flows across roles and course contexts.
  * Expanded end-to-end checks to verify access allowed, denied, and unauthenticated behavior.
  * Added cross-course validation to confirm users can’t access content outside their assigned course.

* **Bug Fixes**
  * Improved detection of incorrect access states, including denied overlays and expected HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->