### PR TITLE
`Testing`: Boot the certificate phase module in the e2e stack

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -81,6 +81,10 @@ services:
         condition: service_started
       client-assessment:
         condition: service_started
+      server-certificate:
+        condition: service_started
+      client-certificate:
+        condition: service_started
     # Adds the /self-team-allocation/* proxy locations that Traefik provides
     # in prod (client prefix stripped, API prefix kept).
     volumes:
@@ -254,6 +258,79 @@ services:
         [
           "CMD-SHELL",
           "pg_isready -d ${DB_ASSESSMENT_NAME} -U ${DB_ASSESSMENT_USER}",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ── Certificate phase module (server + MF remote + own DB) ───────────────
+  # Third phase module in the e2e stack, following the blueprint in
+  # e2e/README.md ("Phase modules in the e2e stack").
+  server-certificate:
+    build:
+      context: ./servers/certificate
+      # Certificate ships its own Dockerfile (bundles the Typst compiler +
+      # golang-migrate), unlike the phase servers that share ../Dockerfile.
+      dockerfile: Dockerfile
+    container_name: prompt-e2e-server-certificate
+    depends_on:
+      db-certificate:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+    # No host port: reached only through the client-core nginx proxy.
+    environment:
+      - CORE_HOST
+      - SERVER_CORE_HOST
+      - SERVER_ADDRESS
+      - SSL_MODE
+      # The service reads generic DB_USER/DB_PASSWORD/DB_NAME but
+      # service-specific host/port vars.
+      - DB_USER=${DB_CERTIFICATE_USER}
+      - DB_PASSWORD=${DB_CERTIFICATE_PASSWORD}
+      - DB_NAME=${DB_CERTIFICATE_NAME}
+      - DB_HOST_CERTIFICATE=${DB_CERTIFICATE_HOST}
+      - DB_PORT_CERTIFICATE=${DB_CERTIFICATE_PORT}
+      - KEYCLOAK_HOST
+      - KEYCLOAK_REALM_NAME
+      - DEBUG
+    # Distroless image (no shell/wget), so no container healthcheck.
+    # Readiness is polled by the runner's global-setup via
+    # /certificate/api/info through the client-core proxy.
+
+  client-certificate:
+    build:
+      context: ./clients/certificate_component
+      dockerfile: Dockerfile
+      args: *client-build-args
+      additional_contexts: *client-additional-contexts
+    container_name: prompt-e2e-client-certificate
+    depends_on:
+      - clients-base
+    # No host port: the remote is served through the client-core nginx proxy
+    # at /certificate/ (prefix stripped, like Traefik in prod).
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:80/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  db-certificate:
+    image: "postgres:15.18-alpine"
+    container_name: prompt-e2e-db-certificate
+    environment:
+      - POSTGRES_USER=${DB_CERTIFICATE_USER}
+      - POSTGRES_PASSWORD=${DB_CERTIFICATE_PASSWORD}
+      - POSTGRES_DB=${DB_CERTIFICATE_NAME}
+      - TZ=Europe/Berlin
+    # No seed: the phase server runs its own migrations on the empty DB and the
+    # tests create all phase data themselves.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -d ${DB_CERTIFICATE_NAME} -U ${DB_CERTIFICATE_USER}",
         ]
       interval: 5s
       timeout: 5s
@@ -456,6 +533,11 @@ services:
         condition: service_healthy
       server-assessment:
         # distroless; global-setup polls /assessment/api/info.
+        condition: service_started
+      client-certificate:
+        condition: service_healthy
+      server-certificate:
+        # distroless; global-setup polls /certificate/api/info.
         condition: service_started
     environment:
       - CI

--- a/e2e/.env.e2e
+++ b/e2e/.env.e2e
@@ -66,18 +66,25 @@ DB_ASSESSMENT_NAME=prompt
 DB_ASSESSMENT_USER=prompt-postgres
 DB_ASSESSMENT_PASSWORD=prompt-postgres
 
+# ─── Certificate database ────────────────────────────────────────────────────
+DB_CERTIFICATE_HOST=db-certificate
+DB_CERTIFICATE_PORT=5432
+DB_CERTIFICATE_NAME=prompt
+DB_CERTIFICATE_USER=prompt-postgres
+DB_CERTIFICATE_PASSWORD=prompt-postgres
+
 # ─── Micro-frontend hosts (referenced by the core client's env.js) ──────────
 # Empty = same-origin: the component's API calls go to the browser origin
 # (client-core) and are proxied to the phase server by e2e/nginx/client-core.conf.
 SELF_TEAM_ALLOCATION_HOST=
 ASSESSMENT_HOST=
+CERTIFICATE_HOST=
 # The remaining modules are not part of the e2e stack (yet).
 INTRO_COURSE_HOST=http://localhost:8082
 DEVOPS_CHALLENGE_HOST=http://localhost:9010
 TEAM_ALLOCATION_HOST=http://localhost:8083
 TEMPLATE_HOST=http://localhost:8086
 INTERVIEW_HOST=http://localhost:8087
-CERTIFICATE_HOST=http://localhost:8088
 
 # ─── S3 (SeaweedFS) ─────────────────────────────────────────────────────────
 S3_BUCKET=prompt-files

--- a/e2e/nginx/client-core.conf
+++ b/e2e/nginx/client-core.conf
@@ -30,6 +30,14 @@ server {
     proxy_pass http://client-assessment/;
   }
 
+  location /certificate/api/ {
+    proxy_pass http://server-certificate:8080;
+  }
+
+  location /certificate/ {
+    proxy_pass http://client-certificate/;
+  }
+
   location / {
     gzip_static on;
     root   /usr/share/nginx/html;

--- a/e2e/seed/e2e_seed.sql
+++ b/e2e/seed/e2e_seed.sql
@@ -659,6 +659,8 @@ INSERT INTO public.course_phase_graph VALUES ('d0000001-0000-0000-0000-000000000
 INSERT INTO public.course_phase_graph VALUES ('d0000002-0000-0000-0000-000000000002', 'd0000003-0000-0000-0000-000000000003');
 INSERT INTO public.course_phase_graph VALUES ('d0000003-0000-0000-0000-000000000003', 'd0000004-0000-0000-0000-000000000004');
 INSERT INTO public.course_phase_graph VALUES ('d0000004-0000-0000-0000-000000000004', 'd0000005-0000-0000-0000-000000000005');
+-- Certificate appended to the tail of the iPraktikumFull chain (after Assessment).
+INSERT INTO public.course_phase_graph VALUES ('d0000005-0000-0000-0000-000000000005', 'd0000009-0000-0000-0000-000000000009');
 
 
 
@@ -703,6 +705,12 @@ INSERT INTO public.course_phase_participation VALUES ('a0000004-0000-0000-0000-0
 INSERT INTO public.course_phase_participation (course_participation_id, course_phase_id, restricted_data, pass_status, student_readable_data) VALUES ('a0000001-0000-0000-0000-000000000001', 'd0000006-0000-0000-0000-000000000006', '{}', 'not_assessed', '{}');
 INSERT INTO public.course_phase_participation (course_participation_id, course_phase_id, restricted_data, pass_status, student_readable_data) VALUES ('ca000008-0000-4000-8000-000000000008', 'd0000006-0000-0000-0000-000000000006', '{}', 'not_assessed', '{}');
 INSERT INTO public.course_phase_participation (course_participation_id, course_phase_id, restricted_data, pass_status, student_readable_data) VALUES ('a0000001-0000-0000-0000-000000000001', 'd0000007-0000-0000-0000-000000000007', '{}', 'not_assessed', '{}');
+-- Certificate phases (see the course_phase inserts below): Stan participates in
+-- the graph-tail phase (smoke + API reads) and both standalone journey phases
+-- (lecturer participants table + staff download, student self-download).
+INSERT INTO public.course_phase_participation (course_participation_id, course_phase_id, restricted_data, pass_status, student_readable_data) VALUES ('a0000001-0000-0000-0000-000000000001', 'd0000009-0000-0000-0000-000000000009', '{}', 'passed', '{}');
+INSERT INTO public.course_phase_participation (course_participation_id, course_phase_id, restricted_data, pass_status, student_readable_data) VALUES ('a0000001-0000-0000-0000-000000000001', 'd000000a-0000-0000-0000-00000000000a', '{}', 'passed', '{}');
+INSERT INTO public.course_phase_participation (course_participation_id, course_phase_id, restricted_data, pass_status, student_readable_data) VALUES ('a0000001-0000-0000-0000-000000000001', 'd000000b-0000-0000-0000-00000000000b', '{}', 'passed', '{}');
 
 
 
@@ -721,6 +729,7 @@ INSERT INTO public.course_phase_type VALUES ('b1111111-1111-1111-1111-1111111111
 INSERT INTO public.course_phase_type VALUES ('b2222222-2222-2222-2222-222222222222', 'Matching', false, 'core', 'A placeholder description for this course phase type. Detailed description will follow.');
 INSERT INTO public.course_phase_type VALUES ('b3333333-3333-3333-3333-333333333333', 'Team Allocation', false, '{CORE_HOST}/team-allocation/api', 'A placeholder description for this course phase type. Detailed description will follow.');
 INSERT INTO public.course_phase_type VALUES ('b4444444-4444-4444-4444-444444444444', 'Assessment', false, '{CORE_HOST}/assessment/api', 'A placeholder description for this course phase type. Detailed description will follow.');
+INSERT INTO public.course_phase_type VALUES ('c5555555-5555-5555-5555-555555555555', 'Certificate', false, '{CORE_HOST}/certificate/api', 'Certificate of completion generation and distribution.');
 
 
 --
@@ -767,6 +776,20 @@ INSERT INTO public.course_phase VALUES ('d0000006-0000-0000-0000-000000000006', 
 INSERT INTO public.course_phase VALUES ('d0000007-0000-0000-0000-000000000007', 'c0000001-0000-0000-0000-000000000001', 'Assessment Self Evaluation', '{}', false, 'b4444444-4444-4444-4444-444444444444', '{}');
 INSERT INTO public.course_phase VALUES ('d0000008-0000-0000-0000-000000000008', 'be780b32-a678-4b79-ae1c-80071771d254', 'Assessment', '{}', false, 'b4444444-4444-4444-4444-444444444444', '{}');
 
+--
+-- Certificate phases. d0000009 is the graph-tail phase on iPraktikumFull
+-- (smoke + API-auth reads, left unconfigured). d000000a / d000000b are
+-- standalone fixtures (no graph edge, route by URL) so the lecturer journey's
+-- template/release state and the student journey's downloads never cross when
+-- Playwright runs the spec files in parallel. d000000c is the TestCourse
+-- negative-auth fixture (no participants; the e2e students are not enrolled).
+--
+
+INSERT INTO public.course_phase VALUES ('d0000009-0000-0000-0000-000000000009', 'c0000001-0000-0000-0000-000000000001', 'Certificate', '{}', false, 'c5555555-5555-5555-5555-555555555555', '{}');
+INSERT INTO public.course_phase VALUES ('d000000a-0000-0000-0000-00000000000a', 'c0000001-0000-0000-0000-000000000001', 'Certificate Lecturer', '{}', false, 'c5555555-5555-5555-5555-555555555555', '{}');
+INSERT INTO public.course_phase VALUES ('d000000b-0000-0000-0000-00000000000b', 'c0000001-0000-0000-0000-000000000001', 'Certificate Student', '{}', false, 'c5555555-5555-5555-5555-555555555555', '{}');
+INSERT INTO public.course_phase VALUES ('d000000c-0000-0000-0000-00000000000c', 'be780b32-a678-4b79-ae1c-80071771d254', 'Certificate', '{}', false, 'c5555555-5555-5555-5555-555555555555', '{}');
+
 
 --
 -- Data for Name: course_phase_type_participation_provided_output_dto; Type: TABLE DATA; Schema: public; Owner: -
@@ -788,6 +811,8 @@ INSERT INTO public.course_phase_type_participation_provided_output_dto VALUES ('
 
 -- Mirrors core's InsertTeamAllocationRequiredInput for the Assessment type.
 INSERT INTO public.course_phase_type_participation_required_input_dto VALUES ('d1000006-0000-4000-8000-000000000006', 'b4444444-4444-4444-4444-444444444444', 'teamAllocation', '{"type": "string"}');
+-- Mirrors core's InsertTeamAllocationRequiredInput for the Certificate type.
+INSERT INTO public.course_phase_type_participation_required_input_dto VALUES ('d1000008-0000-4000-8000-000000000008', 'c5555555-5555-5555-5555-555555555555', 'teamAllocation', '{"type": "string"}');
 
 
 --
@@ -804,6 +829,8 @@ INSERT INTO public.course_phase_type_phase_provided_output_dto VALUES ('d1000002
 
 -- Mirrors core's InsertTeamRequiredInput for the Assessment type.
 INSERT INTO public.course_phase_type_phase_required_input_dto VALUES ('d1000007-0000-4000-8000-000000000007', 'b4444444-4444-4444-4444-444444444444', 'teams', '{"type": "array", "items": {"type": "object", "properties": {"id": {"type": "string"}, "name": {"type": "string"}}, "required": ["id", "name"]}}');
+-- Mirrors core's InsertTeamRequiredInput for the Certificate type.
+INSERT INTO public.course_phase_type_phase_required_input_dto VALUES ('d1000009-0000-4000-8000-000000000009', 'c5555555-5555-5555-5555-555555555555', 'teams', '{"type": "array", "items": {"type": "object", "properties": {"id": {"type": "string"}, "name": {"type": "string"}}, "required": ["id", "name"]}}');
 
 
 

--- a/e2e/src/data/constants.ts
+++ b/e2e/src/data/constants.ts
@@ -85,6 +85,27 @@ export const ASSESSMENT_FIXTURE_PHASES = {
 // students must be rejected (negative auth fixture).
 export const ASSESSMENT_FOREIGN_PHASE_ID = 'd0000008-0000-0000-0000-000000000008'
 
+// Certificate phase appended to the tail of the iPraktikumFull graph (after
+// Assessment). Left unconfigured, so it hosts the module-federation smoke test
+// and the side-effect-free API-auth reads without colliding with the journeys.
+export const CERTIFICATE_PHASES = {
+  graphTail: 'd0000009-0000-0000-0000-000000000009',
+}
+
+// Standalone Certificate phases on fullCourse (no graph edges, navigate by
+// URL). One phase per mutating spec file so template/release-date state and
+// download recording never leak between parallel Playwright files:
+// `lecturer` hosts the lecturer journey (template + release + participants),
+// `student` the student self-download journey (Stan participates in both).
+export const CERTIFICATE_FIXTURE_PHASES = {
+  lecturer: 'd000000a-0000-0000-0000-00000000000a',
+  student: 'd000000b-0000-0000-0000-00000000000b',
+}
+
+// Certificate phase on TestCourse with NO participants: requests by the e2e
+// students must be rejected (negative auth fixture).
+export const CERTIFICATE_FOREIGN_PHASE_ID = 'd000000c-0000-0000-0000-00000000000c'
+
 // The student mapping to the Keycloak `student` role user (Stan); participates in
 // every phase of fullCourse. Course access is DB-derived (matriculation + university
 // login), not a Keycloak role. Same student row as SEEDED_PHASE_STUDENTS.student.

--- a/e2e/src/env.ts
+++ b/e2e/src/env.ts
@@ -16,6 +16,7 @@ export const KEYCLOAK_CLIENT_ID = 'prompt-client'
 // phase server by e2e/nginx/client-core.conf, mirroring prod Traefik routing.
 export const SELF_TEAM_ALLOCATION_API = '/self-team-allocation/api'
 export const ASSESSMENT_API = '/assessment/api'
+export const CERTIFICATE_API = '/certificate/api'
 
 export const tokenEndpoint = () =>
   `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -4,7 +4,13 @@ import { chromium, FullConfig, request } from '@playwright/test'
 import { ROLES, SEEDED_ROLES } from './data/roles'
 import { LoginPage } from './pages/LoginPage'
 import { authFile } from './fixtures/auth'
-import { ASSESSMENT_API, BASE_URL, CORE_API_URL, SELF_TEAM_ALLOCATION_API } from './env'
+import {
+  ASSESSMENT_API,
+  BASE_URL,
+  CERTIFICATE_API,
+  CORE_API_URL,
+  SELF_TEAM_ALLOCATION_API,
+} from './env'
 
 // Poll a URL until it responds (any HTTP status), or time out. The core server
 // image is distroless (no container healthcheck), so we gate readiness here.
@@ -82,6 +88,7 @@ export default async function globalSetup(_config: FullConfig) {
     'self-team-allocation',
   )
   await waitForServiceInfo(`${BASE_URL}${ASSESSMENT_API}/info`, 'assessment')
+  await waitForServiceInfo(`${BASE_URL}${CERTIFICATE_API}/info`, 'certificate')
 
   const browser = await chromium.launch()
   try {

--- a/e2e/src/pages/CertificatePage.ts
+++ b/e2e/src/pages/CertificatePage.ts
@@ -53,9 +53,8 @@ export class CertificatePage {
 
   async saveTemplate() {
     await this.page.getByRole('button', { name: 'Save Template' }).click()
-    await expect(this.page.getByText('Configured', { exact: true })).toBeVisible({
-      timeout: 15_000,
-    })
+    // The "Configured" badge appends "· <date> by <user>", so match a substring.
+    await expect(this.page.getByText(/Configured/)).toBeVisible({ timeout: 15_000 })
   }
 
   // Generates a preview PDF from the saved template. A valid template opens the

--- a/e2e/src/pages/CertificatePage.ts
+++ b/e2e/src/pages/CertificatePage.ts
@@ -1,0 +1,88 @@
+import { Page, Locator, expect } from '@playwright/test'
+
+// /management/course/:courseId/:phaseId — the Certificate remote (Module
+// Federation) rendered inside the core shell. Staff configure the template and
+// release date and see the participants download table; students see their
+// certificate status and self-download once released.
+export class CertificatePage {
+  constructor(private readonly page: Page) {}
+
+  async goto(courseId: string, phaseId: string, subpath = '') {
+    await this.page.goto(`/management/course/${courseId}/${phaseId}${subpath}`)
+  }
+
+  // ── Student overview (phase root) ────────────────────────────────────────
+
+  async expectOverviewLoaded() {
+    await expect(this.page.getByRole('heading', { name: 'Course Certificate' })).toBeVisible({
+      timeout: 15_000,
+    })
+  }
+
+  downloadButton(): Locator {
+    return this.page.getByRole('button', { name: 'Download Certificate' })
+  }
+
+  async expectNotAvailable(message: string | RegExp) {
+    await expect(this.page.getByText(message)).toBeVisible({ timeout: 15_000 })
+    await expect(this.downloadButton()).toBeHidden()
+  }
+
+  // Clicks the student self-download button and returns the captured download.
+  async downloadOwnCertificate() {
+    const downloadPromise = this.page.waitForEvent('download')
+    await this.downloadButton().click()
+    return downloadPromise
+  }
+
+  async expectLastDownloaded() {
+    await expect(this.page.getByText(/Last downloaded:/)).toBeVisible({ timeout: 15_000 })
+  }
+
+  // ── Settings ─────────────────────────────────────────────────────────────
+
+  async expectSettingsLoaded() {
+    await expect(this.page.getByRole('heading', { name: 'Certificate Settings' })).toBeVisible({
+      timeout: 15_000,
+    })
+  }
+
+  async pasteTemplate(content: string) {
+    await this.page.getByPlaceholder('Paste your Typst template content here...').fill(content)
+  }
+
+  async saveTemplate() {
+    await this.page.getByRole('button', { name: 'Save Template' }).click()
+    await expect(this.page.getByText('Configured', { exact: true })).toBeVisible({
+      timeout: 15_000,
+    })
+  }
+
+  // Generates a preview PDF from the saved template. A valid template opens the
+  // PDF in a new tab; an invalid one surfaces the compilation-error alert, so a
+  // successful preview is the absence of that alert.
+  async testCertificate() {
+    await this.page.getByRole('button', { name: 'Test Certificate' }).click()
+    await expect(this.page.getByText('Template Compilation Error')).toBeHidden()
+  }
+
+  async releaseNow() {
+    await this.page.getByRole('button', { name: 'Release Now' }).click()
+    // The Clear button only renders once a release date is set.
+    await expect(this.page.getByRole('button', { name: 'Clear' })).toBeVisible({ timeout: 15_000 })
+  }
+
+  // ── Participants ─────────────────────────────────────────────────────────
+
+  async expectParticipantsLoaded() {
+    await expect(
+      this.page.getByRole('heading', { name: 'Certificate Participants' }),
+    ).toBeVisible({ timeout: 15_000 })
+  }
+
+  async expectParticipantRow(fullName: string, downloadStatus: string) {
+    const row = this.page.getByRole('row', { name: new RegExp(fullName) })
+    await expect(row).toBeVisible()
+    await expect(row).toContainText(downloadStatus)
+  }
+}

--- a/e2e/src/pages/CertificatePage.ts
+++ b/e2e/src/pages/CertificatePage.ts
@@ -57,18 +57,27 @@ export class CertificatePage {
     await expect(this.page.getByText(/Configured/)).toBeVisible({ timeout: 15_000 })
   }
 
-  // Generates a preview PDF from the saved template. A valid template opens the
-  // PDF in a new tab; an invalid one surfaces the compilation-error alert, so a
-  // successful preview is the absence of that alert.
+  // Generates a preview PDF from the saved template. Awaiting the preview
+  // response asserts the template actually compiled server-side (200); a broken
+  // template would return 422 and fail here.
   async testCertificate() {
+    const responsePromise = this.page.waitForResponse((res) =>
+      res.url().includes('/certificate/preview'),
+    )
     await this.page.getByRole('button', { name: 'Test Certificate' }).click()
-    await expect(this.page.getByText('Template Compilation Error')).toBeHidden()
+    const response = await responsePromise
+    expect(response.ok()).toBeTruthy()
   }
 
+  // Awaits the release-date response so the release is confirmed persisted
+  // before the caller navigates away (which would otherwise abort the request).
   async releaseNow() {
+    const responsePromise = this.page.waitForResponse((res) =>
+      res.url().includes('/config/release-date'),
+    )
     await this.page.getByRole('button', { name: 'Release Now' }).click()
-    // The Clear button only renders once a release date is set.
-    await expect(this.page.getByRole('button', { name: 'Clear' })).toBeVisible({ timeout: 15_000 })
+    const response = await responsePromise
+    expect(response.ok()).toBeTruthy()
   }
 
   // ── Participants ─────────────────────────────────────────────────────────

--- a/e2e/src/pages/CertificatePage.ts
+++ b/e2e/src/pages/CertificatePage.ts
@@ -61,8 +61,8 @@ export class CertificatePage {
   // response asserts the template actually compiled server-side (200); a broken
   // template would return 422 and fail here.
   async testCertificate() {
-    const responsePromise = this.page.waitForResponse((res) =>
-      res.url().includes('/certificate/preview'),
+    const responsePromise = this.page.waitForResponse(
+      (res) => res.url().includes('/certificate/preview') && res.request().method() === 'GET',
     )
     await this.page.getByRole('button', { name: 'Test Certificate' }).click()
     const response = await responsePromise
@@ -72,8 +72,8 @@ export class CertificatePage {
   // Awaits the release-date response so the release is confirmed persisted
   // before the caller navigates away (which would otherwise abort the request).
   async releaseNow() {
-    const responsePromise = this.page.waitForResponse((res) =>
-      res.url().includes('/config/release-date'),
+    const responsePromise = this.page.waitForResponse(
+      (res) => res.url().includes('/config/release-date') && res.request().method() === 'PUT',
     )
     await this.page.getByRole('button', { name: 'Release Now' }).click()
     const response = await responsePromise

--- a/e2e/tests/api/certificate.api.spec.ts
+++ b/e2e/tests/api/certificate.api.spec.ts
@@ -1,0 +1,64 @@
+import { request } from '@playwright/test'
+import { test, expect } from '../../src/fixtures/api'
+import { BASE_URL, CERTIFICATE_API } from '../../src/env'
+import { CERTIFICATE_FOREIGN_PHASE_ID, CERTIFICATE_PHASES } from '../../src/data/constants'
+
+// The certificate server is reached on the browser origin through the e2e
+// nginx proxy (same path prefix as prod Traefik). prompt-sdk auth answers 401
+// both for missing tokens and for valid tokens lacking the required role.
+// All checks are side-effect-free (GET only) on the graph-tail certificate
+// phase, which the journeys never touch.
+const phaseUrl = (phaseId: string, path: string) =>
+  `${BASE_URL}${CERTIFICATE_API}/course_phase/${phaseId}/${path}`
+
+const PHASE_ID = CERTIFICATE_PHASES.graphTail
+
+test.describe('certificate API auth', () => {
+  test('rejects unauthenticated requests', async () => {
+    const anon = await request.newContext()
+    try {
+      const res = await anon.get(phaseUrl(PHASE_ID, 'config'))
+      expect(res.status()).toBe(401)
+    } finally {
+      await anon.dispose()
+    }
+  })
+
+  test('rejects a student on the template download endpoint', async ({ apiAs }) => {
+    // config/template is staff-only; students hold the Student role only.
+    const api = await apiAs('student')
+    const res = await api.get(phaseUrl(PHASE_ID, 'config/template'))
+    expect(res.status()).toBe(401)
+  })
+
+  test('rejects a student on the participants endpoint', async ({ apiAs }) => {
+    const api = await apiAs('student')
+    const res = await api.get(phaseUrl(PHASE_ID, 'participants'))
+    expect(res.status()).toBe(401)
+  })
+
+  test('rejects a student on the preview endpoint', async ({ apiAs }) => {
+    // Preview is limited to admins and lecturers.
+    const api = await apiAs('student')
+    const res = await api.get(phaseUrl(PHASE_ID, 'certificate/preview'))
+    expect(res.status()).toBe(401)
+  })
+
+  test('accepts a course editor on the participants endpoint', async ({ apiAs }) => {
+    const api = await apiAs('course-editor')
+    const res = await api.get(phaseUrl(PHASE_ID, 'participants'))
+    expect(res.status()).toBe(200)
+  })
+
+  test('accepts an enrolled student on the status endpoint', async ({ apiAs }) => {
+    const api = await apiAs('student')
+    const res = await api.get(phaseUrl(PHASE_ID, 'certificate/status'))
+    expect(res.status()).toBe(200)
+  })
+
+  test('rejects a student on a phase of a course they are not enrolled in', async ({ apiAs }) => {
+    const api = await apiAs('student')
+    const res = await api.get(phaseUrl(CERTIFICATE_FOREIGN_PHASE_ID, 'certificate/status'))
+    expect(res.status()).toBe(401)
+  })
+})

--- a/e2e/tests/api/certificate.api.spec.ts
+++ b/e2e/tests/api/certificate.api.spec.ts
@@ -1,23 +1,20 @@
 import { request } from '@playwright/test'
 import { test, expect } from '../../src/fixtures/api'
-import { BASE_URL, CERTIFICATE_API } from '../../src/env'
 import { CERTIFICATE_FOREIGN_PHASE_ID, CERTIFICATE_PHASES } from '../../src/data/constants'
+import { certificateUrl } from '../certificate/helpers'
 
 // The certificate server is reached on the browser origin through the e2e
 // nginx proxy (same path prefix as prod Traefik). prompt-sdk auth answers 401
 // both for missing tokens and for valid tokens lacking the required role.
 // All checks are side-effect-free (GET only) on the graph-tail certificate
 // phase, which the journeys never touch.
-const phaseUrl = (phaseId: string, path: string) =>
-  `${BASE_URL}${CERTIFICATE_API}/course_phase/${phaseId}/${path}`
-
 const PHASE_ID = CERTIFICATE_PHASES.graphTail
 
 test.describe('certificate API auth', () => {
   test('rejects unauthenticated requests', async () => {
     const anon = await request.newContext()
     try {
-      const res = await anon.get(phaseUrl(PHASE_ID, 'config'))
+      const res = await anon.get(certificateUrl(PHASE_ID, 'config'))
       expect(res.status()).toBe(401)
     } finally {
       await anon.dispose()
@@ -27,38 +24,38 @@ test.describe('certificate API auth', () => {
   test('rejects a student on the template download endpoint', async ({ apiAs }) => {
     // config/template is staff-only; students hold the Student role only.
     const api = await apiAs('student')
-    const res = await api.get(phaseUrl(PHASE_ID, 'config/template'))
+    const res = await api.get(certificateUrl(PHASE_ID, 'config/template'))
     expect(res.status()).toBe(401)
   })
 
   test('rejects a student on the participants endpoint', async ({ apiAs }) => {
     const api = await apiAs('student')
-    const res = await api.get(phaseUrl(PHASE_ID, 'participants'))
+    const res = await api.get(certificateUrl(PHASE_ID, 'participants'))
     expect(res.status()).toBe(401)
   })
 
   test('rejects a student on the preview endpoint', async ({ apiAs }) => {
     // Preview is limited to admins and lecturers.
     const api = await apiAs('student')
-    const res = await api.get(phaseUrl(PHASE_ID, 'certificate/preview'))
+    const res = await api.get(certificateUrl(PHASE_ID, 'certificate/preview'))
     expect(res.status()).toBe(401)
   })
 
   test('accepts a course editor on the participants endpoint', async ({ apiAs }) => {
     const api = await apiAs('course-editor')
-    const res = await api.get(phaseUrl(PHASE_ID, 'participants'))
+    const res = await api.get(certificateUrl(PHASE_ID, 'participants'))
     expect(res.status()).toBe(200)
   })
 
   test('accepts an enrolled student on the status endpoint', async ({ apiAs }) => {
     const api = await apiAs('student')
-    const res = await api.get(phaseUrl(PHASE_ID, 'certificate/status'))
+    const res = await api.get(certificateUrl(PHASE_ID, 'certificate/status'))
     expect(res.status()).toBe(200)
   })
 
   test('rejects a student on a phase of a course they are not enrolled in', async ({ apiAs }) => {
     const api = await apiAs('student')
-    const res = await api.get(phaseUrl(CERTIFICATE_FOREIGN_PHASE_ID, 'certificate/status'))
+    const res = await api.get(certificateUrl(CERTIFICATE_FOREIGN_PHASE_ID, 'certificate/status'))
     expect(res.status()).toBe(401)
   })
 })

--- a/e2e/tests/certificate/helpers.ts
+++ b/e2e/tests/certificate/helpers.ts
@@ -1,0 +1,60 @@
+import { APIRequestContext } from '@playwright/test'
+import { apiContextFor } from '../../src/fixtures/api'
+import { Role } from '../../src/data/roles'
+import { BASE_URL, CERTIFICATE_API } from '../../src/env'
+
+// All certificate API calls go through the client-core nginx proxy on the
+// browser origin (same path prefix as prod Traefik), NOT the core API.
+export function certificateUrl(phaseId: string, path: string): string {
+  return `${BASE_URL}${CERTIFICATE_API}/course_phase/${phaseId}/${path}`
+}
+
+// A minimal, valid Typst template the bundled compiler (in the certificate
+// image) can render. It reads the data.json the server writes and references
+// only studentName + courseName, so it compiles for phases without team data.
+export const E2E_TEMPLATE = [
+  '#let data = json("data.json")',
+  '#set page(paper: "a4")',
+  '= Certificate of Completion',
+  'This certifies that #data.studentName has completed #data.courseName.',
+].join('\n')
+
+async function put(
+  role: Role,
+  phaseId: string,
+  path: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const api: APIRequestContext = await apiContextFor(role)
+  try {
+    const res = await api.put(certificateUrl(phaseId, path), { data })
+    if (!res.ok()) {
+      throw new Error(`PUT ${path} failed: ${res.status()} ${await res.text()}`)
+    }
+  } finally {
+    await api.dispose()
+  }
+}
+
+export async function putTemplate(
+  phaseId: string,
+  templateContent: string,
+  role: Role = 'lecturer',
+): Promise<void> {
+  await put(role, phaseId, 'config', { templateContent })
+}
+
+export async function setReleaseDate(
+  phaseId: string,
+  releaseDate: string | null,
+  role: Role = 'lecturer',
+): Promise<void> {
+  await put(role, phaseId, 'config/release-date', { releaseDate })
+}
+
+// Idempotent teardown so CI retries (which reuse the ephemeral DB) stay
+// deterministic. Certificate downloads cannot be un-recorded, but clearing the
+// release date restores the phase's release gating.
+export async function resetCertificatePhase(phaseId: string, role: Role = 'admin'): Promise<void> {
+  await setReleaseDate(phaseId, null, role)
+}

--- a/e2e/tests/certificate/lecturer-journey.spec.ts
+++ b/e2e/tests/certificate/lecturer-journey.spec.ts
@@ -1,0 +1,40 @@
+import { test } from '../../src/fixtures/auth'
+import { CertificatePage } from '../../src/pages/CertificatePage'
+import {
+  CERTIFICATE_FIXTURE_PHASES,
+  SEEDED_COURSES,
+  SEEDED_PHASE_STUDENTS,
+} from '../../src/data/constants'
+import { E2E_TEMPLATE, resetCertificatePhase } from './helpers'
+
+const PHASE_ID = CERTIFICATE_FIXTURE_PHASES.lecturer
+const STUDENT_NAME = `${SEEDED_PHASE_STUDENTS.student.firstName} ${SEEDED_PHASE_STUDENTS.student.lastName}`
+
+// The `lecturer` user holds the course-scoped ios2425-iPraktikumFull-Lecturer role.
+test.use({ role: 'lecturer' })
+
+test.describe('certificate: lecturer journey', () => {
+  test.afterAll(async () => {
+    await resetCertificatePhase(PHASE_ID)
+  })
+
+  test('a lecturer configures the template, previews it, and releases it', async ({ page }) => {
+    const phase = new CertificatePage(page)
+
+    // Configure the certificate template.
+    await phase.goto(SEEDED_COURSES.fullCourse.id, PHASE_ID, '/settings')
+    await phase.expectSettingsLoaded()
+    await phase.pasteTemplate(E2E_TEMPLATE)
+    await phase.saveTemplate()
+
+    // Trigger generation: preview compiles the template (no error), and
+    // Release Now makes the certificate available to students.
+    await phase.testCertificate()
+    await phase.releaseNow()
+
+    // The participants table shows the seeded student and their download status.
+    await phase.goto(SEEDED_COURSES.fullCourse.id, PHASE_ID, '/participants')
+    await phase.expectParticipantsLoaded()
+    await phase.expectParticipantRow(STUDENT_NAME, 'Not downloaded')
+  })
+})

--- a/e2e/tests/certificate/mf-smoke.spec.ts
+++ b/e2e/tests/certificate/mf-smoke.spec.ts
@@ -1,0 +1,17 @@
+import { test } from '../../src/fixtures/auth'
+import { CertificatePage } from '../../src/pages/CertificatePage'
+import { CERTIFICATE_PHASES, SEEDED_COURSES } from '../../src/data/constants'
+
+// Module Federation smoke test: the phase page is rendered by the
+// certificate_component REMOTE, loaded by the core shell from
+// /certificate/remoteEntry.js through the e2e nginx proxy. If the remote fails
+// to load, the shell renders a LoadingError instead of the heading.
+test.use({ role: 'course-lecturer' })
+
+test.describe('certificate: module federation smoke', () => {
+  test('the remote loads and renders inside the core shell', async ({ page }) => {
+    const phase = new CertificatePage(page)
+    await phase.goto(SEEDED_COURSES.fullCourse.id, CERTIFICATE_PHASES.graphTail)
+    await phase.expectOverviewLoaded()
+  })
+})

--- a/e2e/tests/certificate/student-journey.spec.ts
+++ b/e2e/tests/certificate/student-journey.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '../../src/fixtures/auth'
+import { CertificatePage } from '../../src/pages/CertificatePage'
+import { CERTIFICATE_FIXTURE_PHASES, SEEDED_COURSES } from '../../src/data/constants'
+import { E2E_TEMPLATE, putTemplate, resetCertificatePhase, setReleaseDate } from './helpers'
+
+const PHASE_ID = CERTIFICATE_FIXTURE_PHASES.student
+
+// The `student` user (Stan) participates in this phase; course access is
+// DB-derived from the matriculation/login token claims.
+test.use({ role: 'student' })
+
+test.describe('certificate: student journey', () => {
+  test.beforeAll(async () => {
+    // Lecturer sets up a configured but not-yet-released certificate.
+    await putTemplate(PHASE_ID, E2E_TEMPLATE)
+    await setReleaseDate(PHASE_ID, new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString())
+  })
+
+  test.afterAll(async () => {
+    await resetCertificatePhase(PHASE_ID)
+  })
+
+  test('a student downloads their certificate once it is released', async ({ page }) => {
+    const phase = new CertificatePage(page)
+
+    // Before release the certificate is gated.
+    await phase.goto(SEEDED_COURSES.fullCourse.id, PHASE_ID)
+    await phase.expectOverviewLoaded()
+    await phase.expectNotAvailable(/will be available after/i)
+
+    // The lecturer releases the certificate (release date in the past).
+    await setReleaseDate(PHASE_ID, new Date(Date.now() - 60 * 1000).toISOString())
+
+    // The student can now download the generated PDF.
+    await phase.goto(SEEDED_COURSES.fullCourse.id, PHASE_ID)
+    await phase.expectOverviewLoaded()
+    const download = await phase.downloadOwnCertificate()
+    expect(download.suggestedFilename()).toBe('certificate.pdf')
+
+    // The download is recorded and surfaced on the overview.
+    await phase.goto(SEEDED_COURSES.fullCourse.id, PHASE_ID)
+    await phase.expectLastDownloaded()
+  })
+})


### PR DESCRIPTION
# 📝 Pull Request Template

## ✨ What is the change?

Adds the certificate phase module (`servers/certificate` + `clients/certificate_component`) to the Playwright e2e stack, following the same blueprint already used for the `assessment` and `self_team_allocation` modules (documented in `e2e/README.md` → "Phase modules in the e2e stack").

- **Stack wiring** (`docker-compose.e2e.yml`): new `server-certificate`, `client-certificate`, and `db-certificate` services (the server uses its own `servers/certificate/Dockerfile`, which bundles the Typst compiler), added to `client-core` and `e2e-runner` `depends_on`.
- **Routing / env** (`e2e/nginx/client-core.conf`, `e2e/.env.e2e`): `/certificate/api/` (prefix kept) and `/certificate/` (prefix stripped) proxy locations, a `DB_CERTIFICATE_*` block, and `CERTIFICATE_HOST=` (empty = same-origin).
- **Readiness** (`e2e/src/env.ts`, `e2e/src/global-setup.ts`): `CERTIFICATE_API` constant and a `/certificate/api/info` readiness poll.
- **Seed** (`e2e/seed/e2e_seed.sql`): a fixed-UUID `Certificate` `course_phase_type` (mirroring core's `initCertificate`, incl. the `teamAllocation`/`teams` required-input DTOs), a graph-tail certificate phase on `iPraktikumFull`, two standalone journey fixtures, a `TestCourse` negative-auth fixture, and the student participations.
- **Tests** (`e2e/tests/certificate/*`, `e2e/tests/api/certificate.api.spec.ts`, `e2e/src/pages/CertificatePage.ts`):
  - Module-federation smoke (the remote loads inside the core shell).
  - Lecturer journey: configure the Typst template, preview it (server compiles), release it, and see the participants download table.
  - Student journey: certificate is release-gated, then self-downloaded once released.
  - API auth matrix: certificate endpoints reject unauthenticated and wrong-role requests (401), accept the allowed roles, and reject a student on a foreign course phase.

Each mutating spec owns its own seeded phase so template/release-date state and download recording never leak between parallel Playwright workers.

## 📌 Reason for the change / Link to issue

The certificate service and client had no e2e coverage and were not part of the e2e stack, so regressions in certificate generation/distribution or its auth could ship unnoticed. This extends `make test-e2e` to boot the module and exercise the lecturer/student journeys and API auth end to end.

Closes #1822. Depends on #1810 and #1811 (assessment module, already merged).

## 🧪 How to Test

1. `make test-e2e` — the full Dockerized stack boots `server-certificate` / `client-certificate` / `db-certificate`, global-setup's `/certificate/api/info` poll passes, and all specs are green (52 passed locally, including the 7 new certificate specs).
2. For interactive debugging: `make test-e2e-ui` (open http://127.0.0.1:8123) and step through `tests/certificate/*`.
3. `make test-e2e-down` to tear down the stack and volumes.

## 🖼️ Screenshots (if UI changes are included)

<!-- No UI changes: this PR only adds e2e test infrastructure and tests. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the certificate experience, including overview, settings, release flow, participant status, and download behavior.
  * Added a new certificate module to the E2E environment with routing, startup checks, and test data.
  * Added certificate-specific helper utilities and page interactions for automated testing.

* **Bug Fixes**
  * Improved service readiness checks so tests wait for certificate-related components before running.
  * Updated routing so certificate pages and API requests are handled consistently through the shared proxy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->