### PR TITLE
`Assessment`: Fix statistics tooltip blocking the view of the chart

### DIFF
--- a/clients/assessment_component/src/assessment/pages/components/diagrams/gradeDistributionBarChart/GradeDistributionBarChart.tsx
+++ b/clients/assessment_component/src/assessment/pages/components/diagrams/gradeDistributionBarChart/GradeDistributionBarChart.tsx
@@ -62,7 +62,12 @@ export function GradeDistributionBarChart({ data }: GradeDistributionBarChartPro
         >
           <Label value='Grade' angle={-90} position='insideLeft' fill='#a3a3a3' />
         </YAxis>
-        <ChartTooltip cursor={false} content={<GradeDistributionTooltipContent />} />
+        <ChartTooltip
+          cursor={false}
+          allowEscapeViewBox={{ x: false, y: true }}
+          wrapperStyle={{ zIndex: 50 }}
+          content={<GradeDistributionTooltipContent />}
+        />
         <Bar dataKey='value' shape={<GradeDistributionBar />}>
           <LabelList dataKey='average' content={<GradeDistributionLabel />} />
         </Bar>

--- a/clients/assessment_component/src/assessment/pages/components/diagrams/scoreDistributionBarChart/ScoreDistributionBarChart.tsx
+++ b/clients/assessment_component/src/assessment/pages/components/diagrams/scoreDistributionBarChart/ScoreDistributionBarChart.tsx
@@ -62,7 +62,12 @@ export function ScoreDistributionBarChart({ data }: ScoreDistributionBarChartPro
         >
           <Label value='Score Level' angle={-90} position='insideLeft' fill='#a3a3a3' />
         </YAxis>
-        <ChartTooltip cursor={false} content={<ScoreDistributionTooltipContent />} />
+        <ChartTooltip
+          cursor={false}
+          allowEscapeViewBox={{ x: false, y: true }}
+          wrapperStyle={{ zIndex: 50 }}
+          content={<ScoreDistributionTooltipContent />}
+        />
         <Bar dataKey='value' shape={<ScoreDistributionBar />}>
           <LabelList dataKey='average' content={<ScoreDistributionLabel />} />
         </Bar>


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

The quartile tooltips of the score distribution and grade distribution bar charts on the assessment statistics page now follow the mouse pointer instead of being pinned over the chart. The tooltip is taller than the 280px chart, so recharts clamped it into the chart viewbox, where it covered the whole diagram. The tooltip may now escape the viewbox vertically (`allowEscapeViewBox={{ x: false, y: true }}`), so it hangs below the pointer and leaves the bars visible; horizontally it still flips to the other side of the pointer near the chart edge, and `zIndex` keeps it above neighboring cards.

## 📌 Reason for the change / Link to issue

Closes #585 — the hover tooltip blocked the view of the statistic it describes.

## 🧪 How to Test

1. Open a course with an assessment phase and go to `Assessment` → `Statistics`.
2. Hover over a bar in any of the "Detailed Grade Statistics" or "Detailed Score Level Statistics" diagrams (e.g. Gender Distribution).
3. The tooltip follows the mouse pointer below the hover position and no longer covers the chart; move along the bars and check that it flips sides near the right edge instead of leaving the screen.

## 🖼️ Screenshots (if UI changes are included)

| Before | After |
| -------------- | ------------- |
| ![before](https://github.com/user-attachments/assets/78b98df5-2f47-4cad-a9b8-c918422eb1ad) | ![after](https://raw.githubusercontent.com/prompt-edu/prompt/assets/issue-585-tooltip/tooltip-follows-pointer.png) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
