### PR TITLE
`Assessment`: Fix DeleteAssessment swallowing DB errors and returning 200 on missing lookup

### DIFF
--- a/servers/assessment/assessments/router.go
+++ b/servers/assessment/assessments/router.go
@@ -248,6 +248,7 @@ func getMyAssessmentResults(c *gin.Context) {
 // @Param assessmentID path string true "Assessment ID"
 // @Success 200 {string} string "OK"
 // @Failure 400 {object} map[string]string
+// @Failure 404 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /course_phase/{coursePhaseID}/student-assessment/{assessmentID} [delete]
 func deleteAssessment(c *gin.Context) {
@@ -262,7 +263,7 @@ func deleteAssessment(c *gin.Context) {
 		return
 	}
 	if err := DeleteAssessment(c, assessmentID, coursePhaseID); err != nil {
-		if errors.Is(err, ErrAssessmentNotInPhase) {
+		if errors.Is(err, ErrAssessmentNotInPhase) || errors.Is(err, ErrAssessmentNotFound) {
 			handleError(c, http.StatusNotFound, err)
 			return
 		}

--- a/servers/assessment/assessments/service.go
+++ b/servers/assessment/assessments/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
@@ -37,6 +38,7 @@ var AssessmentServiceSingleton *AssessmentService
 var ErrInvalidScoreLevel = errors.New("validation failed: scoreLevel is required and must be valid")
 var ErrUnsupportedAssessmentExportFormat = errors.New("unsupported assessment export format")
 var ErrAssessmentNotInPhase = errors.New("assessment does not belong to this course phase")
+var ErrAssessmentNotFound = errors.New("assessment not found")
 
 const AssessmentExportFormatJSON = "json"
 
@@ -346,8 +348,11 @@ func DeleteAssessment(ctx context.Context, id, coursePhaseID uuid.UUID) error {
 
 	assessment, err := qtx.GetAssessment(ctx, id)
 	if err != nil {
-		log.Info("assessment not found, nothing to delete: ", err)
-		return nil
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrAssessmentNotFound
+		}
+		log.Error("could not get assessment for deletion: ", err)
+		return fmt.Errorf("could not get assessment: %w", err)
 	}
 
 	if assessment.CoursePhaseID != coursePhaseID {

--- a/servers/assessment/assessments/service_test.go
+++ b/servers/assessment/assessments/service_test.go
@@ -90,7 +90,7 @@ func (suite *AssessmentServiceTestSuite) TestDeleteAssessmentNonExisting() {
 	id := uuid.New()
 	coursePhaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
 	err := DeleteAssessment(suite.suiteCtx, id, coursePhaseID)
-	assert.NoError(suite.T(), err, "Deleting non-existent assessment should not error")
+	assert.ErrorIs(suite.T(), err, ErrAssessmentNotFound, "Deleting non-existent assessment should return not-found")
 }
 
 func (suite *AssessmentServiceTestSuite) TestCreateOrUpdateAssessmentWithEmptyScoreLevel() {

--- a/servers/assessment/docs/docs.go
+++ b/servers/assessment/docs/docs.go
@@ -4283,6 +4283,15 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/servers/assessment/docs/swagger.json
+++ b/servers/assessment/docs/swagger.json
@@ -4277,6 +4277,15 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/servers/assessment/docs/swagger.yaml
+++ b/servers/assessment/docs/swagger.yaml
@@ -2931,6 +2931,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Internal Server Error
           schema:


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

`DeleteAssessment` no longer treats every error from `GetAssessment` as "not found". It now:

- returns a typed `ErrAssessmentNotFound` sentinel only when the lookup returns `pgx.ErrNoRows`, which the handler maps to `404`; and
- propagates every other error (e.g. a transient connection/timeout) so the handler returns `500`.

The delete handler maps `ErrAssessmentNotFound` to `404` (alongside the existing `ErrAssessmentNotInPhase`), and the Swagger annotation now documents the `404` response.

## 📌 Reason for the change / Link to issue

Closes #1775.

Previously the lookup error was blanket-matched and the function returned `nil`, so:

- a transient DB error was reported to the client as a successful delete even though the row still existed and the editability check + delete never ran; and
- a genuinely missing `assessmentID` returned `200` instead of `404`, so callers could not distinguish the two.

## 🧪 How to Test

1. `cd servers/assessment && go test ./assessments/` — `TestDeleteAssessmentNonExisting` now asserts `DeleteAssessment` returns `ErrAssessmentNotFound` for a missing ID.
2. `DELETE /course_phase/{coursePhaseID}/student-assessment/{assessmentID}` with a non-existent assessment ID now returns `404` instead of `200`.

## 🖼️ Screenshots (if UI changes are included)

<!-- No UI changes. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting an assessment that does not exist now returns a clear “not found” response.
  * Deletion requests for assessments in an invalid phase are also reported as not found.
  * Other deletion failures continue to return an internal server error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->