### PR TITLE
`Assessment`: Fix empty grade silently persisted as 5.0 on remarks blur

### DIFF
--- a/clients/assessment_component/package.json
+++ b/clients/assessment_component/package.json
@@ -7,7 +7,6 @@
     "dev": "rspack serve --mode development",
     "lint": "biome check src",
     "lint:fix": "biome check src --fix",
-    "test": "../node_modules/.bin/ts-node --compiler-options '{\"module\":\"commonjs\"}' src/assessment/pages/SettingsPage/components/AssessmentReminderCard/utils.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit --pretty false",
     "build": "rspack --mode=production --env NODE_ENV=production",
     "check-performance": "rspack --mode=production --env NODE_ENV=production --env BUNDLE_SIZE=true"

--- a/clients/assessment_component/src/assessment/pages/utils/gradeConfig.ts
+++ b/clients/assessment_component/src/assessment/pages/utils/gradeConfig.ts
@@ -32,7 +32,7 @@ export const validateGrade = (
   gradeString: string,
 ): { isValid: boolean; value?: number; error?: string } => {
   if (!gradeString || gradeString.trim() === '') {
-    return { isValid: true, value: 5.0 }
+    return { isValid: false, error: 'a grade must be selected' }
   }
 
   const gradeValue = parseFloat(gradeString)


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

`validateGrade('')` in `clients/assessment_component/src/assessment/pages/utils/gradeConfig.ts` returned `{ isValid: true, value: 5.0 }`, so an empty/unset grade was treated as a real `5.0` (Fail). Blurring the General Remarks textarea (or clicking "Mark Assessment as Final") before a grade was selected silently persisted `gradeSuggestion = 5.0` a tutor never entered, which then surfaced in the Grade select, statistics, and participant views.

This PR makes an empty grade **invalid** (`{ isValid: false, error: 'a grade must be selected' }`). Both call sites (`handleSaveFormData` and `handleConfirm` in `AssessmentCompletion.tsx`) already bail on `!isValid`, so no completion is written until a real grade is chosen no phantom `5.0` is ever saved.

Note: the issue's alternative suggestion (persist no grade / omit `gradeSuggestion`) isn't viable the assessment service (`servers/assessment/.../assessmentCompletion/service.go`) rejects any `gradeSuggestion` outside `[1.0, 5.0]`, so a completion can't be stored without a real grade. Treating empty as invalid is the correct option.

Also removed the `test` script from `clients/assessment_component/package.json`: it pointed at `AssessmentReminderCard/utils.test.ts`, a file that no longer exists, and client testing in this repo is end-to-end (Playwright) only.

## 📌 Reason for the change / Link to issue

Closes #1776.

## 🧪 How to Test

1. Open a fresh assessment for a student that has no completion yet, leaving the Grade select empty.
2. Type something into **General Remarks** and click away (blur) without selecting a grade.
3. Confirm no grade is persisted: the Grade select stays empty (no "Fail - 5.0"), and an inline "a grade must be selected" message is shown instead of a silent save.
4. Try **Mark Assessment as Final** with no grade selected confirm it is blocked with the same message.
5. Select a real grade (e.g. `2.0`) and confirm saving and finalizing work as before.

## 🖼️ Screenshots (if UI changes are included)

<!-- No visual changes; behavior-only fix. -->

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
