### PR TITLE
`Assessment`: Fix double status write in getMyGradeSuggestion

### DIFF
--- a/servers/assessment/assessments/assessmentCompletion/router.go
+++ b/servers/assessment/assessments/assessmentCompletion/router.go
@@ -356,6 +356,7 @@ func getMyGradeSuggestion(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusOK, completion.GradeSuggestion)
+		return
 	}
 	c.Status(http.StatusNoContent)
 }


### PR DESCRIPTION
## ✨ What is the change?

Added a missing `return` in `getMyGradeSuggestion` (`servers/assessment/assessments/assessmentCompletion/router.go`) after `c.JSON(http.StatusOK, completion.GradeSuggestion)`, so the handler no longer falls through to the trailing `c.Status(http.StatusNoContent)` after already writing the `200` body.

## 📌 Reason for the change / Link to issue

The `c.JSON(http.StatusOK, ...)` call inside the `if exists` block was missing a `return`, so after writing the `200` response the handler continued to the trailing `c.Status(http.StatusNoContent)` (intended only for the `exists == false` path). This triggered Gin's "headers already written" warning: a latent double-write bug and log noise, fragile to future refactors. The trailing `c.Status(http.StatusNoContent)` still correctly serves the `exists == false` path, so its behavior is unchanged.

Closes #1792

## 🧪 How to Test

1. Check out this branch and run `cd servers/assessment`.
2. `go build ./...`, `go vet ./assessments/assessmentCompletion/...`, `go test ./assessments/assessmentCompletion/...` — all pass.
3. Exercise `GET /my-grade-suggestion` for a student whose assessment is completed: response is `200` with the grade suggestion body and no `[GIN] headers were already written` warning in the server log.

## 🖼️ Screenshots (if UI changes are included)

N/A — backend-only change.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed) — existing package tests cover the handler; no behavior change to test
- [ ] Screenshots attached for UI changes (if any) — N/A
- [ ] Documentation updated (if relevant) — N/A
