### PR TITLE
`Assessment`: Fix tutor evaluation without deadline permanently disabling "Unmark as Final"

### DIFF
--- a/clients/assessment_component/src/assessment/pages/EvaluationPages/TutorEvaluationPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/EvaluationPages/TutorEvaluationPage.tsx
@@ -73,7 +73,7 @@ export const TutorEvaluationPage = () => {
 
       <EvaluationCompletionPage
         type={AssessmentType.TUTOR}
-        deadline={coursePhaseConfig?.tutorEvaluationDeadline ?? new Date()}
+        deadline={coursePhaseConfig?.tutorEvaluationDeadline}
         courseParticipationID={courseParticipationID ?? ''}
         authorCourseParticipationID={myParticipation?.courseParticipationID ?? ''}
         completed={(completion?.completed ?? false) || !isStudent}

--- a/clients/assessment_component/src/assessment/pages/EvaluationPages/components/EvaluationCompletionPage/EvaluationCompletionPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/EvaluationPages/components/EvaluationCompletionPage/EvaluationCompletionPage.tsx
@@ -13,12 +13,15 @@ import { useUnmarkMyEvaluationAsCompleted } from './hooks/useUnmarkMyEvaluationA
 
 interface EvaluationCompletionPageProps {
   type: AssessmentType
-  deadline: Date
+  deadline?: Date
   courseParticipationID: string
   authorCourseParticipationID: string
   completed?: boolean
   completedAt?: Date
 }
+
+const hasDeadline = (deadline?: Date): deadline is Date =>
+  deadline !== undefined && new Date(deadline).getFullYear() > 1
 
 export const EvaluationCompletionPage = ({
   type,
@@ -45,7 +48,8 @@ export const EvaluationCompletionPage = ({
 
   const isPending = isMarkPending || isUnmarkPending
 
-  const isDeadlinePassed = deadline ? new Date() > new Date(deadline) : false
+  const deadlineSet = hasDeadline(deadline)
+  const isDeadlinePassed = deadlineSet && new Date() > new Date(deadline)
 
   const handleConfirm = () => {
     const handleCompletion = async () => {
@@ -116,7 +120,7 @@ export const EvaluationCompletionPage = ({
 
       <div className='flex justify-between items-center mt-8'>
         <div className='flex flex-col'>
-          {deadline && (
+          {deadlineSet && (
             <div className='text-muted-foreground'>
               <DeadlineBadge deadline={deadline} type={type} />
             </div>


### PR DESCRIPTION
## ✨ What is the change?

Treats an unset tutor-evaluation deadline (serialized by the server as the Go zero time `0001-01-01T00:00:00Z`) as "no deadline" on the client. A small `hasDeadline` type guard (year > 1) in `EvaluationCompletionPage` now drives both the `isDeadlinePassed` check and the `DeadlineBadge` render, and `TutorEvaluationPage` passes the raw config value instead of the misleading `?? new Date()` fallback.

## 📌 Reason for the change / Link to issue

When a tutor evaluation has no deadline configured, "Unmark as Final" was permanently disabled and a bogus "Deadline passed: 01.01.0001" badge was shown.

`tutor_evaluation_deadline` is nullable (migration `0016_add_tutor_evaluation`), and the server serializes an unset deadline as `0001-01-01T00:00:00Z`. On the client:
- `TutorEvaluationPage` passed the deadline through with a `?? new Date()` fallback that never fired, because the value is a valid (very old) date rather than `null`/`undefined`.
- `EvaluationCompletionPage` computed `isDeadlinePassed = new Date() > new Date(deadline)`, always `true` for `0001-01-01`.
- The unmark button is disabled on `completed && isDeadlinePassed`, and the badge rendered "Deadline passed: 01.01.0001".

Self and peer deadlines are `NOT NULL`, so only the tutor path was affected. With the fix, when no tutor deadline is set, `isDeadlinePassed` is `false`, "Unmark as Final" is enabled, and no deadline badge is shown.

Closes #1793

## 🧪 How to Test

1. Open a tutor evaluation phase configured **without** a tutor deadline.
2. Mark the tutor evaluation as final.
3. Verify "Unmark as Final" is enabled (not greyed out) and no "Deadline passed: 01.01.0001" badge is shown.
4. Regression: a tutor evaluation **with** a real past deadline still disables "Unmark as Final" and shows the deadline-passed badge.
5. Checks: from `clients/`, `biome check` on the changed files and `tsc -p assessment_component/tsconfig.json --noEmit` both pass.

## 🖼️ Screenshots (if UI changes are included)

| Before | After |
| ------ | ----- |
| "Unmark as Final" disabled, "Deadline passed: 01.01.0001" badge shown | "Unmark as Final" enabled, no deadline badge |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed) — no existing test files in the assessment component; kept the guard local (no established pattern)
- [ ] Screenshots attached for UI changes (if any) — described above; can attach captures if required
- [ ] Documentation updated (if relevant) — N/A
