### PR TITLE
`Assessment`: Show self/peer evaluation average when a single entry exists

### DIFF
--- a/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentCompletion/components/GradeSuggestion.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentPage/components/AssessmentCompletion/components/GradeSuggestion.tsx
@@ -50,7 +50,7 @@ export const GradeSuggestion = ({
       <CardHeader>
         <CardTitle className='mb-3'>Grade</CardTitle>
         {selfEvaluations &&
-          selfEvaluations.length > 1 &&
+          selfEvaluations.length > 0 &&
           (() => {
             const weightedScoreLevel = getWeightedScoreLevel(
               selfEvaluations,
@@ -67,7 +67,7 @@ export const GradeSuggestion = ({
             )
           })()}
         {peerEvaluations &&
-          peerEvaluations.length > 1 &&
+          peerEvaluations.length > 0 &&
           (() => {
             const weightedScoreLevel = getWeightedScoreLevel(
               peerEvaluations,


### PR DESCRIPTION
## ✨ What is the change?

The self and peer evaluation average badges in the `GradeSuggestion` card were guarded by `selfEvaluations.length > 1` / `peerEvaluations.length > 1`. This is an off-by-one: when a student has exactly one evaluation entry (a single-competency schema, or a student who evaluated exactly one competency), the average badge was hidden even though `evaluationResultsVisible` was enabled and a valid weighted score existed.

Both guards are now `> 0`, consistent with the sibling "Your Assessment Average" guard in the same component (`studentScore.scoreNumeric > 0`), which renders the badge whenever a valid score exists. `getWeightedScoreLevel` already computes a correct average for a single entry, so no other change was needed.

## 📌 Reason for the change / Link to issue

With a single-competency schema, or a student who evaluated exactly one competency, `length === 1` and the average badge was not rendered. Tutors then graded without seeing the student's self/peer assessment.

Closes #1777

## 🧪 How to Test

1. Enable self and/or peer evaluation for a course phase, with `evaluationResultsVisible` on.
2. Have a student submit exactly one self/peer evaluation entry (or use a single-competency evaluation schema).
3. Open the assessment completion view for that student as a tutor.
4. Verify the "Self Evaluation Average" / "Peer Evaluation Average" badge is now displayed. Before this change it was hidden for a single entry.

## 🖼️ Screenshots (if UI changes are included)

No visual redesign; the existing average badge now also renders for the single-entry case.

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
