### PR TITLE
`Application`: Fix infinite loading spinner when authenticated user has no email

### DIFF
--- a/clients/core/src/publicPages/application/pages/ApplicationAuthenticated/ApplicationAuthenticated.tsx
+++ b/clients/core/src/publicPages/application/pages/ApplicationAuthenticated/ApplicationAuthenticated.tsx
@@ -43,9 +43,9 @@ export const ApplicationAuthenticated = () => {
     isError: isApplicationError,
     error: applicationError,
   } = useQuery<GetApplication>({
-    queryKey: ['application', phaseId, user?.email],
+    queryKey: ['application', phaseId],
     queryFn: () => getApplication(phaseId ?? ''),
-    enabled: !!phaseId && !!user?.email && !!localStorage.getItem('jwt_token'),
+    enabled: !!phaseId && !!localStorage.getItem('jwt_token'),
   })
 
   const { mutate: mutateSendApplication, error: mutateError } = useMutation({
@@ -53,7 +53,7 @@ export const ApplicationAuthenticated = () => {
       return postNewApplicationAuthenticated(phaseId ?? 'undefined', modifiedApplication)
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['application', phaseId, user?.email] })
+      queryClient.invalidateQueries({ queryKey: ['application', phaseId] })
       setConfirmationMailSent(data.confirmationMailSent)
       setShowDialog('success')
     },


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

The authenticated application page (`/apply/{phaseId}/authenticated`) no longer gates its `application` query on `user.email`. The `enabled` condition and the query key now depend only on the phase and the JWT token, and the mutation's invalidation key was updated to match.

## 📌 Reason for the change / Link to issue

Fixes #1764.

`user.email` comes from the Keycloak `email` claim and is defaulted to `''` in `useKeycloak` when the claim is absent. When a logged-in student's Keycloak account has no email, `enabled` was `false`, so the query never ran. In react-query v5 a disabled query stays `isPending: true`, and the render guard `if (isPending || isApplicationPending)` left the page stuck forever on "Loading application form…" with no error and no timeout.

Authorization is via the JWT, not the email, so the query should not depend on `user.email`.

## 🧪 How to Test

1. Use a Keycloak student account with **no** email address set.
2. Open a course application, choose "Log in with TUM-ID", and authenticate.
3. Land on `/apply/{phaseId}/authenticated` and confirm the application form loads (previously it hung on the loading spinner). The network trace should now show `GET /api/apply/authenticated/{phaseId}`.

## 🖼️ Screenshots (if UI changes are included)

<!-- No visual changes. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authenticated application loading by using the active session token and phase information.
  * Updated application data refresh behavior after submissions to ensure the latest information is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->