### PR TITLE
`Application`: Fix advanced settings collapsing when toggling export settings

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationQuestionConfigPage/FormPages/ApplicationQuestionCard.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationQuestionConfigPage/FormPages/ApplicationQuestionCard.tsx
@@ -91,7 +91,6 @@ export const ApplicationQuestionCard = forwardRef<
   const isMultiSelectType = 'options' in question
   const isFileUploadType = 'allowedFileTypes' in question
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false)
 
   const status: QuestionStatus = originalQuestion
     ? questionsEqual(question, originalQuestion)
@@ -134,14 +133,17 @@ export const ApplicationQuestionCard = forwardRef<
     return !hasAnyAdvanced
   }
 
+  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(
+    () => !shouldCollapseAdvancedOptions(form.getValues()),
+  )
+
   useEffect(() => {
     const subscription = form.watch((value) => {
       onUpdate({ ...question, ...value })
     })
-    setAdvancedSettingsOpen(!shouldCollapseAdvancedOptions(form.getValues()))
     // Cleanup subscription on unmount
     return () => subscription.unsubscribe()
-  }, [form.watch, question, onUpdate, form, shouldCollapseAdvancedOptions])
+  }, [form, question, onUpdate])
 
   // allow to call validate from the parent component
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

In the application question configuration card, the "Advanced Settings" collapsible no longer snaps shut while the user is interacting with it. The panel's open state is now initialized once with a lazy `useState` initializer, and the reset call was removed from the `form.watch` subscription effect (whose dependency array contained unstable `onUpdate` and `shouldCollapseAdvancedOptions` references that re-ran it on almost every render).

## 📌 Reason for the change / Link to issue

Fixes #1681.

Toggling an Export Settings switch calls `setCsvExportSettings` on the parent, which re-renders it and hands the card a fresh inline `onUpdate` reference. That changed the effect's dependencies, so the effect re-ran and executed `setAdvancedSettingsOpen(!shouldCollapseAdvancedOptions(...))`. Because the export flag is not one of the "advanced" values that keeps the panel open, the section collapsed under the user's cursor.

## 🧪 How to Test

1. Open the Application phase of a course and go to the Questions page.
2. Open a question and expand its Advanced Settings section.
3. Toggle the Export Settings switch(es).
4. Confirm the Advanced Settings section stays open (previously it collapsed on toggle).

## 🖼️ Screenshots (if UI changes are included)

<!-- Behavior fix only; see issue #1681 for the before recording. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
