### PR TITLE
`Self Team Allocation`: Fix overview page unauthorized for managers enrolled as students

### DIFF
--- a/clients/self_team_allocation_component/src/self_team_allocation/pages/TeamAllocation/SelfTeamAllocationPage.tsx
+++ b/clients/self_team_allocation_component/src/self_team_allocation/pages/TeamAllocation/SelfTeamAllocationPage.tsx
@@ -2,7 +2,10 @@ import { useQuery } from '@tanstack/react-query'
 import {
   type CoursePhaseParticipationWithStudent,
   getOwnCoursePhaseParticipation,
+  getPermissionString,
+  Role,
   type Team,
+  useAuthStore,
   useCourseStore,
 } from '@tumaet/prompt-shared-state'
 import {
@@ -20,9 +23,14 @@ import { getTimeframe } from '../../network/queries/getSurveyTimeframe'
 import { TeamSelection } from './components/TeamSelection'
 
 export const SelfTeamAllocationPage = () => {
-  const { isStudentOfCourse } = useCourseStore()
+  const { courses, isStudentOfCourse } = useCourseStore()
+  const { permissions } = useAuthStore()
   const { courseId = '', phaseId = '' } = useParams<{ courseId: string; phaseId: string }>()
-  const isStudent = isStudentOfCourse(courseId)
+  const course = courses.find((c) => c.id === courseId)
+  const isManager = [Role.PROMPT_ADMIN, Role.COURSE_LECTURER, Role.COURSE_EDITOR].some((role) =>
+    permissions.includes(getPermissionString(role, course?.name, course?.semesterTag)),
+  )
+  const isStudent = isStudentOfCourse(courseId) && !isManager
 
   const {
     data: participation,


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

On the Self Team Allocation overview page, the management role now takes priority over student enrollment. `isStudent` is only true when the user is enrolled as a student **and** is not an admin/lecturer/editor of the course, so managers no longer take the student-only code path.

## 📌 Reason for the change / Link to issue

Fixes #1455.

The page derived `isStudent` from `isStudentOfCourse(courseId)` alone. A user enrolled in the course as both a student and a manager therefore ran the student-only `getOwnCoursePhaseParticipation` query, which 404s for a manager (they have no own participation record). The page mapped that 404 to `UnauthorizedPage`, locking admins/instructors out of the student-visible overview. Student status was effectively overriding management privileges, the inverse of the intended precedence. This mirrors the `PermissionRestriction` pattern in core, where the student/`ownCourseIDs` grant never revokes an already-granted manager.

## 🧪 How to Test

1. Enroll a user in a course as **both** a student and an instructor/lecturer (or be a PROMPT admin who is also a course student).
2. Open the Self Team Allocation phase and go to the Overview (student-visible) page in the management view.
3. Confirm the page renders (teams/timeframe) instead of showing the Unauthorized error.
4. As a pure student, confirm the team-allocation flow still works as before.

## 🖼️ Screenshots (if UI changes are included)

<!-- No new visual elements; the previously blocked page now renders. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
