### PR TITLE
`Assessment`: Add course phase link placeholder to evaluation reminder mails

### DIFF
--- a/clients/assessment_component/src/assessment/pages/SettingsPage/components/AssessmentReminderCard/AssessmentReminderCard.tsx
+++ b/clients/assessment_component/src/assessment/pages/SettingsPage/components/AssessmentReminderCard/AssessmentReminderCard.tsx
@@ -270,7 +270,8 @@ export const AssessmentReminderCard = () => {
                 Available placeholders:{' '}
                 <span className='font-mono text-foreground'>{'{{firstName}}'}</span>,{' '}
                 <span className='font-mono text-foreground'>{'{{evaluationType}}'}</span>,{' '}
-                <span className='font-mono text-foreground'>{'{{evaluationDeadline}}'}</span>
+                <span className='font-mono text-foreground'>{'{{evaluationDeadline}}'}</span>,{' '}
+                <span className='font-mono text-foreground'>{'{{coursePhaseLink}}'}</span>
               </p>
             </div>
           </div>

--- a/servers/core/mailing/manualMail.go
+++ b/servers/core/mailing/manualMail.go
@@ -57,6 +57,8 @@ func SendManualMailToParticipants(
 		return report, fmt.Errorf("failed to load course mailing context: %w", err)
 	}
 
+	coursePhaseLink := buildCoursePhaseLink(ctx, coursePhaseID)
+
 	for _, participant := range participants {
 		if !participant.Email.Valid || participant.Email.String == "" {
 			failedIdentifier := participant.UniversityLogin.String
@@ -79,6 +81,9 @@ func SendManualMailToParticipants(
 			passedMailingInfo.CourseEndDate,
 			db.GetParticipantMailingInformationRow(participant),
 		)
+		if coursePhaseLink != "" {
+			placeholderMap["coursePhaseLink"] = coursePhaseLink
+		}
 		for key, value := range request.AdditionalPlaceholders {
 			placeholderMap[key] = value
 		}
@@ -97,6 +102,16 @@ func SendManualMailToParticipants(
 
 	report.SentAt = nowFn()
 	return report, nil
+}
+
+func buildCoursePhaseLink(ctx context.Context, coursePhaseID uuid.UUID) string {
+	courseID, err := MailingServiceSingleton.queries.GetCourseIDByCoursePhaseID(ctx, coursePhaseID)
+	if err != nil {
+		log.WithError(err).WithField("coursePhaseID", coursePhaseID).
+			Warn("Failed to resolve course for manual mail course phase link")
+		return ""
+	}
+	return fmt.Sprintf("%s/management/course/%s/%s", MailingServiceSingleton.clientURL, courseID, coursePhaseID)
 }
 
 func deduplicateUUIDList(values []uuid.UUID) []uuid.UUID {

--- a/servers/core/mailing/manualMail_test.go
+++ b/servers/core/mailing/manualMail_test.go
@@ -149,6 +149,38 @@ func (suite *ManualMailServiceTestSuite) TestSendManualMailHappyPath() {
 	}
 }
 
+func (suite *ManualMailServiceTestSuite) TestSendManualMailCoursePhaseLinkPlaceholder() {
+	oldClientURL := MailingServiceSingleton.clientURL
+	MailingServiceSingleton.clientURL = "https://prompt.example.com"
+	defer func() { MailingServiceSingleton.clientURL = oldClientURL }()
+
+	sentMails := make([]sentManualMail, 0)
+	sendMailFn = func(
+		courseMailingSettings mailingDTO.CourseMailingSettings,
+		recipientAddress, subject, htmlBody string,
+	) error {
+		sentMails = append(sentMails, sentManualMail{Recipient: recipientAddress, Content: htmlBody})
+		return nil
+	}
+
+	report, err := SendManualMailToParticipants(
+		suite.ctx,
+		suite.phaseID,
+		mailingDTO.SendManualMailRequest{
+			Subject:                         "Reminder",
+			Content:                         "Open the phase at {{coursePhaseLink}}.",
+			RecipientCourseParticipationIDs: []uuid.UUID{suite.recipient1},
+		},
+	)
+	suite.Require().NoError(err)
+	suite.Require().Len(report.SuccessfulEmails, 1)
+	suite.Require().Len(sentMails, 1)
+
+	expectedLink := "https://prompt.example.com/management/course/11111111-1111-1111-1111-111111111111/33333333-3333-3333-3333-333333333333"
+	assert.Contains(suite.T(), sentMails[0].Content, expectedLink)
+	assert.False(suite.T(), strings.Contains(sentMails[0].Content, "{{"))
+}
+
 func (suite *ManualMailServiceTestSuite) TestSendManualMailNoRecipients() {
 	fixedNow := time.Date(2026, time.January, 14, 8, 0, 0, 0, time.UTC)
 	nowFn = func() time.Time { return fixedNow }


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Adds a `{{coursePhaseLink}}` placeholder to manual course mails. The core mailing service now resolves the course of the target phase and injects a link to the course phase (`<clientURL>/management/course/<courseID>/<coursePhaseID>`) into the placeholder map for every manual mail. The assessment evaluation reminder can therefore include a direct link to the phase, and the reminder template editor lists the new placeholder as available.

## 📌 Reason for the change / Link to issue

Closes #1896. Reminder recipients had no direct way to reach the course phase they were reminded about. Building the link in core keeps the client base URL and the course lookup in the one service that already owns them, and makes the placeholder reusable for any manual mail.

## 🧪 How to Test

1. Configure an assessment reminder template on the Assessment `Settings` page and include `{{coursePhaseLink}}` in the message.
2. Ensure an evaluation type is enabled and its deadline has passed.
3. Trigger the reminder and inspect the sent mail; the placeholder resolves to `<clientURL>/management/course/<courseID>/<coursePhaseID>`.
4. `cd servers/core && go test ./mailing/` runs the new `TestSendManualMailCoursePhaseLinkPlaceholder` case.

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)
