### PR TITLE
`Documentation`: Add pull request structure guide

### DIFF
--- a/docs/contributor/guide/index.md
+++ b/docs/contributor/guide/index.md
@@ -62,6 +62,7 @@ Next to the general golden rules and best practices, the following defines stric
 
 - [Client Guidelines](./client.md)
 - [Server Guidelines](./server.md)
+- [Pull Request Structure](./pull_requests.md)
 
 
 ---

--- a/docs/contributor/guide/pull_requests.md
+++ b/docs/contributor/guide/pull_requests.md
@@ -53,7 +53,7 @@ Keep all headings, helper text, and checklist items, and tick the boxes that app
 ## Before you open the PR
 
 - `make lint` and `make test` pass.
-- Backend: protected routes sit under `/api/course_phase/:coursePhaseID` with the correct roles,
+- Server: protected routes sit under `/api/course_phase/:coursePhaseID` with the correct roles,
   and `db/sqlc/` is regenerated and committed alongside any migration or query change.
-- Frontend: no `any`, and shared libraries are reused over custom code.
+- Client: no `any`, and shared libraries are reused over custom code.
 - Tests are added or updated for the behavior you changed.

--- a/docs/contributor/guide/pull_requests.md
+++ b/docs/contributor/guide/pull_requests.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 5
+---
+
+# Pull Request Structure
+
+Every change reaches `main` through a pull request. A consistent PR structure keeps the review
+fast and the release notes readable. This page describes how to title and describe a PR.
+
+## Title
+
+Use the format:
+
+```text
+`Tag`: Short description
+```
+
+- The **tag** is backticked and names the affected area.
+- The **description** is a plain, sentence-case summary suitable for release notes (capitalize only
+  the first word). Use `Fix` for bugfixes and another action verb (`Add`, `Allow`, `Show`,
+  `Enable`, …) otherwise. Do not repeat the tag inside the description, and do not add emojis.
+
+Examples:
+
+```text
+`Assessment`: Fix tutor evaluation without deadline blocking Unmark as Final
+`Team Allocation`: Scope tutor access to assigned team
+`Documentation`: Add pull request structure guide
+```
+
+### Available tags
+
+`Core`, `Course Phases`, `Authentication`, `Module Federation`, `Interview`, `Team Allocation`,
+`Matching`, `Assessment`, `Certificate`, `Intro Course`, `Self Team Allocation`, `Templating`,
+`New Phase`, `Database`, `API`, `Testing`, `Documentation`, `Infrastructure`, `Deployment`,
+`UI/UX`, `Performance`, `General`.
+
+Use `General` when none of the others fit.
+
+## Body
+
+Fill in every section of the [PR template](https://github.com/prompt-edu/prompt/blob/main/.github/pull_request_template.md).
+Keep all headings, helper text, and checklist items, and tick the boxes that apply.
+
+| Section                        | What to write                                                              |
+| ------------------------------ | -------------------------------------------------------------------------- |
+| **What is the change?**        | A brief description of what was changed or added.                          |
+| **Reason for the change**      | Why the change was made. Link the related issue (e.g. `Closes #123`).      |
+| **How to Test**                | Numbered steps a reviewer can follow to verify the change.                 |
+| **Screenshots**                | Before/after images for any visual change.                                 |
+| **PR Checklist**               | Tick what is true: tested, clean code, tests updated, screenshots, docs.   |
+
+## Before you open the PR
+
+- `make lint` and `make test` pass.
+- Backend: protected routes sit under `/api/course_phase/:coursePhaseID` with the correct roles,
+  and `db/sqlc/` is regenerated and committed alongside any migration or query change.
+- Frontend: no `any`, and shared libraries are reused over custom code.
+- Tests are added or updated for the behavior you changed.


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Adds a `Pull Request Structure` page to the contributor guide documenting the PR title convention (backticked tag + sentence-case summary), the list of available tags, how to fill in each section of the PR template, and the checks to run before opening a PR. Also links the new page from the contributor guide index.

## 📌 Reason for the change / Link to issue

Closes #870. The PR title/body conventions existed only in tooling and reviewer habit, with nothing in the docs for contributors to follow.

## 🧪 How to Test

1. Open `docs/contributor/guide/pull_requests.md` or run the Docusaurus site.
2. Confirm the page renders and appears in the contributor guide sidebar.
3. Confirm the link from `docs/contributor/guide/index.md` resolves.

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for structuring pull requests.
  * Documented required title formats, available action tags, body sections, and pre-submission checks.
  * Added the new Pull Request Structure guide to the Coding Guidelines index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->