### PR TITLE
`Core`: Add link to application form from application management view

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationLandingPage/ApplicationLandingPage.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationLandingPage/ApplicationLandingPage.tsx
@@ -1,4 +1,5 @@
-import { ManagementPageHeader, MissingConfig } from '@tumaet/prompt-ui-components'
+import { Button, ManagementPageHeader, MissingConfig } from '@tumaet/prompt-ui-components'
+import { ExternalLink } from 'lucide-react'
 import { useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { useParseApplicationMetaData } from '../../hooks/useParseApplicationMetaData'
@@ -31,7 +32,17 @@ export const ApplicationLandingPage = () => {
 
   return (
     <div>
-      <ManagementPageHeader>Application Administration</ManagementPageHeader>
+      <div className='flex items-center justify-between gap-4'>
+        <ManagementPageHeader>Application Administration</ManagementPageHeader>
+        {coursePhase?.id && (
+          <Button asChild variant='outline'>
+            <a href={`/apply/${coursePhase.id}`} target='_blank' rel='noopener noreferrer'>
+              <ExternalLink className='h-4 w-4' />
+              Open Application Form
+            </a>
+          </Button>
+        )}
+      </div>
       <MissingConfig elements={missingConfigs} />
       <div className='grid gap-6 md:grid-cols-2 lg:grid-cols-3 mb-6'>
         <ApplicationStatusCard

--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationLandingPage/ApplicationLandingPage.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationLandingPage/ApplicationLandingPage.tsx
@@ -1,7 +1,7 @@
 import { Button, ManagementPageHeader, MissingConfig } from '@tumaet/prompt-ui-components'
 import { ExternalLink } from 'lucide-react'
 import { useState } from 'react'
-import { useLocation } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { useParseApplicationMetaData } from '../../hooks/useParseApplicationMetaData'
 import type { ApplicationMetaData } from '../../interfaces/applicationMetaData'
 import { getIsApplicationConfigured } from '../../utils/getApplicationIsConfigured'
@@ -36,10 +36,10 @@ export const ApplicationLandingPage = () => {
         <ManagementPageHeader>Application Administration</ManagementPageHeader>
         {coursePhase?.id && (
           <Button asChild variant='outline'>
-            <a href={`/apply/${coursePhase.id}`} target='_blank' rel='noopener noreferrer'>
+            <Link to={`/apply/${coursePhase.id}`} target='_blank' rel='noopener noreferrer'>
               <ExternalLink className='h-4 w-4' />
               Open Application Form
-            </a>
+            </Link>
           </Button>
         )}
       </div>


### PR DESCRIPTION
# 📝 Pull Request Template

## ✨ What is the change?

Adds an **Open Application Form** button to the Application phase landing page (management view).
It opens the student-facing application view (`/apply/:phaseID`) in a new tab, so instructors no
longer have to hand-edit the URL to preview the application.

## 📌 Reason for the change / Link to issue

Instructors previously had to manually adjust the browser URL to reach the student application view.
This adds a direct navigation option, placed on the Application management landing page.

Closes #566

## 🧪 How to Test

1. Open an Application phase in the management console (landing/overview page).
2. Click **Open Application Form** in the page header.
3. Confirm the student application view (`/apply/<phaseID>`) opens in a new tab.

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Open Application Form” link button to the application landing page header.
  * The button appears only when the course phase is available, and opens the corresponding application form in a new browser tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->