### PR TITLE
`Assessment`: Allow opening a participant's assessment in a new tab

### DIFF
--- a/clients/assessment_component/src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage.tsx
@@ -7,7 +7,7 @@ import {
   type TableFilter,
 } from '@tumaet/prompt-ui-components'
 import { Loader2 } from 'lucide-react'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { AssessmentType } from '../../interfaces/assessmentType'
 import { getAllEvaluationCompletionsInPhase } from '../../network/queries/getAllEvaluationCompletionsInPhase'
@@ -32,6 +32,17 @@ export const AssessmentParticipantsPage = () => {
   const { phaseId } = useParams<{ phaseId: string }>()
   const navigate = useNavigate()
   const path = useLocation().pathname
+  // shared table's onClickRowAction doesn't forward the event, so capture the modifier here
+  const openInNewTabRef = useRef(false)
+
+  const openAssessment = (courseParticipationID: string) => {
+    const target = `${path}/${courseParticipationID}`
+    if (openInNewTabRef.current) {
+      window.open(`${window.location.origin}${target}`, '_blank', 'noopener,noreferrer')
+      return
+    }
+    navigate(target)
+  }
 
   const { data: coursePhaseConfig } = useGetCoursePhaseConfig()
   const { data: participations } = useGetCoursePhaseParticipations()
@@ -146,7 +157,8 @@ export const AssessmentParticipantsPage = () => {
     <div id='table-view' className='relative flex flex-col'>
       <ManagementPageHeader>Assessment Participants</ManagementPageHeader>
       <p className='text-sm text-muted-foreground mb-4'>
-        Click on a participant to view/edit their assessment.
+        Click on a participant to view/edit their assessment. Cmd/Ctrl-click to open it in a new
+        tab.
       </p>
       <div className='grid gap-6 grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 mb-6'>
         <AssessmentDiagram
@@ -157,13 +169,18 @@ export const AssessmentParticipantsPage = () => {
         <GradeDistributionDiagram participations={participations} grades={completedGrades} />
         <ScoreLevelDistributionDiagram participations={participations} scoreLevels={scoreLevels} />
       </div>
-      <div className='w-full'>
+      <div
+        className='w-full'
+        onClickCapture={(e) => {
+          openInNewTabRef.current = e.metaKey || e.ctrlKey
+        }}
+      >
         <CoursePhaseParticipationsTable
           phaseId={phaseId!}
           participants={participations ?? []}
           extraColumns={extraColumns}
           extraFilters={extraFilters}
-          onClickRowAction={(row) => navigate(`${path}/${row.courseParticipationID}`)}
+          onClickRowAction={(row) => openAssessment(row.courseParticipationID)}
         />
       </div>
     </div>


### PR DESCRIPTION
# 📝 Pull Request Template

## ✨ What is the change?

On the Assessment **Participants** page, `Cmd`/`Ctrl`-clicking a participant now opens that
participant's assessment page in a **new browser tab**. A plain click still navigates in place as
before. The helper text was updated to mention the shortcut.

## 📌 Reason for the change / Link to issue

Assessors often want to keep the participants overview open while working through individual
assessments. Opening an assessment in a new tab lets them do that.

Closes #772

> Note: the shared `CoursePhaseParticipationsTable` renders rows via an `onClickRowAction` callback
> that does not forward the DOM event, and its rows are not anchors (the component lives in the
> published `prompt-ui-components`). The modifier key is therefore captured on a wrapping element.
> Full middle-click support would require anchor rows in the shared table.

## 🧪 How to Test

1. Open an Assessment phase → `Participants`.
2. Click a participant → the assessment opens in place (unchanged behavior).
3. `Cmd`-click (macOS) or `Ctrl`-click (Windows/Linux) a participant → the assessment opens in a new tab.

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
