### PR TITLE
`Certificate`: Fix preview popup blocked on Safari and mobile

### DIFF
--- a/clients/certificate_component/src/certificate/pages/SettingsPage.tsx
+++ b/clients/certificate_component/src/certificate/pages/SettingsPage.tsx
@@ -142,6 +142,8 @@ export const SettingsPage = () => {
 
     setIsPreviewing(true)
     setCompilerError(null)
+    // Open the tab synchronously within the click gesture so Safari/mobile don't block it.
+    const previewWindow = window.open('', '_blank')
     try {
       // Save first if there are unsaved changes
       if (hasChanges) {
@@ -154,6 +156,7 @@ export const SettingsPage = () => {
             description: 'Template saved before generating preview',
           })
         } catch {
+          previewWindow?.close()
           toast({
             title: 'Save failed',
             description: 'Failed to save template before preview.',
@@ -165,9 +168,18 @@ export const SettingsPage = () => {
 
       const blob = await previewCertificate(phaseId)
       const url = window.URL.createObjectURL(blob)
-      window.open(url, '_blank')
+      if (previewWindow) {
+        previewWindow.location.href = url
+      } else {
+        const link = document.createElement('a')
+        link.href = url
+        link.target = '_blank'
+        link.rel = 'noopener'
+        link.click()
+      }
       setTimeout(() => window.URL.revokeObjectURL(url), 10000)
     } catch (error: unknown) {
+      previewWindow?.close()
       console.error('Failed to generate preview:', error)
       const previewError = error as PreviewError
       if (previewError?.compilerOutput) {


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

The certificate template preview now opens reliably in Safari and on mobile. `handlePreview` in `SettingsPage.tsx` opened the preview tab with `window.open(url, '_blank')` only *after* awaiting the preview compilation, so the call was no longer inside the click gesture and Safari/mobile popup blockers silently swallowed it. The tab is now opened synchronously within the click handler and pointed at the generated blob once it is ready, with an anchor-based fallback if the browser still returns no window.

## 📌 Reason for the change / Link to issue

Closes #1291. On Safari and mobile browsers the "Preview" button did nothing because the popup was blocked. Browsers only allow `window.open` when it runs synchronously in a user-initiated event handler; after an `await` that context is lost.

## 🧪 How to Test

1. Open a Certificate phase's Settings page in Safari (desktop or iOS) or a mobile browser.
2. Edit or load a template and click **Preview**.
3. The compiled certificate opens in a new tab instead of being blocked.
4. Trigger a compile error (invalid template) and confirm the pre-opened tab is closed and the error is shown inline.

## 🖼️ Screenshots (if UI changes are included)

<!-- No visual changes; behavior-only fix. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
