### PR TITLE
`Core`: Delete Keycloak groups and roles on course deletion

### DIFF
--- a/servers/core/course/main.go
+++ b/servers/core/course/main.go
@@ -16,6 +16,7 @@ func InitCourseModule(routerGroup *gin.RouterGroup, queries db.Queries, conn *pg
 		queries:                    queries,
 		conn:                       conn,
 		createCourseGroupsAndRoles: keycloakRealmManager.CreateCourseGroupsAndRoles,
+		deleteCourseGroupsAndRoles: keycloakRealmManager.DeleteCourseGroupsAndRoles,
 	}
 
 	// possibly more setup tasks

--- a/servers/core/course/router_test.go
+++ b/servers/core/course/router_test.go
@@ -45,12 +45,16 @@ func (suite *CourseRouterTestSuite) SetupSuite() {
 		// No-op or add assertions for test
 		return nil
 	}
+	mockDeleteGroupsAndRoles := func(ctx context.Context, courseID uuid.UUID) error {
+		return nil
+	}
 
 	suite.cleanup = cleanup
 	suite.courseService = CourseService{
 		queries:                    *testDB.Queries,
 		conn:                       testDB.Conn,
 		createCourseGroupsAndRoles: mockCreateGroupsAndRoles,
+		deleteCourseGroupsAndRoles: mockDeleteGroupsAndRoles,
 	}
 
 	CourseServiceSingleton = &suite.courseService

--- a/servers/core/course/service.go
+++ b/servers/core/course/service.go
@@ -26,6 +26,7 @@ type CourseService struct {
 	conn    *pgxpool.Pool
 	// use dependency injection for keycloak to allow mocking
 	createCourseGroupsAndRoles func(ctx context.Context, courseName, iterationName, userID string) error
+	deleteCourseGroupsAndRoles func(ctx context.Context, courseID uuid.UUID) error
 }
 
 var CourseServiceSingleton *CourseService
@@ -434,6 +435,14 @@ func UpdateCourseData(ctx context.Context, courseID uuid.UUID, courseData course
 }
 
 func DeleteCourse(ctx context.Context, courseID uuid.UUID) error {
+	// Delete the Keycloak groups and roles first: the group name is derived from
+	// the course row, which must still exist. On failure the course is kept so it
+	// stays deletable on a later retry instead of orphaning its Keycloak state.
+	if err := CourseServiceSingleton.deleteCourseGroupsAndRoles(ctx, courseID); err != nil {
+		log.Error("Failed to delete keycloak groups and roles for course: ", err)
+		return errors.New("failed to delete keycloak groups and roles")
+	}
+
 	ctxWithTimeout, cancel := db.GetTimeoutContext(ctx)
 	defer cancel()
 

--- a/servers/core/course/service_test.go
+++ b/servers/core/course/service_test.go
@@ -42,12 +42,16 @@ func (suite *CourseServiceTestSuite) SetupSuite() {
 		// No-op or add assertions for test
 		return nil
 	}
+	mockDeleteGroupsAndRoles := func(ctx context.Context, courseID uuid.UUID) error {
+		return nil
+	}
 
 	suite.cleanup = cleanup
 	suite.courseService = CourseService{
 		queries:                    *testDB.Queries,
 		conn:                       testDB.Conn,
 		createCourseGroupsAndRoles: mockCreateGroupsAndRoles,
+		deleteCourseGroupsAndRoles: mockDeleteGroupsAndRoles,
 	}
 
 	CourseServiceSingleton = &suite.courseService

--- a/servers/core/keycloakRealmManager/deletingCourse.go
+++ b/servers/core/keycloakRealmManager/deletingCourse.go
@@ -1,0 +1,75 @@
+package keycloakRealmManager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Nerzal/gocloak/v14"
+	"github.com/google/uuid"
+	"github.com/prompt-edu/prompt/servers/core/permissionValidation"
+	log "github.com/sirupsen/logrus"
+)
+
+// DeleteCourseGroupsAndRoles removes the Keycloak artifacts created by
+// CreateCourseGroupsAndRoles: the course group (Keycloak cascades its
+// Lecturer/Editor/CustomGroups subgroups) and the client roles named after the
+// course. It must run before the course row is removed from the database, since
+// the group name is derived from it. A group that is already gone is treated as
+// success so the operation stays idempotent.
+func DeleteCourseGroupsAndRoles(ctx context.Context, courseID uuid.UUID) error {
+	token, err := LoginClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	courseGroupName, err := GetCourseGroupName(ctx, courseID)
+	if err != nil {
+		return fmt.Errorf("failed to get course group name: %w", err)
+	}
+
+	// 1. Delete the course group; Keycloak cascades subgroups and role mappings.
+	group, err := GetCourseGroup(ctx, token.AccessToken, courseID)
+	if err != nil {
+		if !strings.Contains(err.Error(), "404") {
+			return fmt.Errorf("failed to resolve course group: %w", err)
+		}
+		log.Warnf("course %s group not found in Keycloak; skipping group deletion", courseID)
+	} else if err := KeycloakRealmSingleton.client.DeleteGroup(ctx, token.AccessToken, KeycloakRealmSingleton.Realm, *group.ID); err != nil {
+		return fmt.Errorf("failed to delete course group: %w", err)
+	}
+
+	// 2. Delete the client roles. Group deletion only drops the group-role
+	// mapping, not the role definitions themselves.
+	return deleteCourseClientRoles(ctx, token.AccessToken, courseGroupName)
+}
+
+func deleteCourseClientRoles(ctx context.Context, accessToken, courseGroupName string) error {
+	roles, err := KeycloakRealmSingleton.client.GetClientRoles(ctx, accessToken, KeycloakRealmSingleton.Realm, KeycloakRealmSingleton.idOfClient, gocloak.GetRoleParams{})
+	if err != nil {
+		return fmt.Errorf("failed to list client roles: %w", err)
+	}
+
+	for _, role := range roles {
+		if role == nil || role.Name == nil || !isCourseClientRole(*role.Name, courseGroupName) {
+			continue
+		}
+		if err := KeycloakRealmSingleton.client.DeleteClientRole(ctx, accessToken, KeycloakRealmSingleton.Realm, KeycloakRealmSingleton.idOfClient, *role.Name); err != nil {
+			return fmt.Errorf("failed to delete client role %s: %w", *role.Name, err)
+		}
+	}
+	return nil
+}
+
+// isCourseClientRole reports whether a client role was created for the given
+// course. Creation produces "<group>-Lecturer", "<group>-Editor" and custom
+// "<group>-cg-<name>" roles. The staff roles are matched exactly and custom
+// roles by the "-cg-" prefix so a course whose group name is a prefix of
+// another's (e.g. "ws24-ios" vs "ws24-ios-advanced") is not caught by mistake.
+func isCourseClientRole(roleName, courseGroupName string) bool {
+	if roleName == courseGroupName+"-"+permissionValidation.CourseLecturer ||
+		roleName == courseGroupName+"-"+permissionValidation.CourseEditor {
+		return true
+	}
+	return strings.HasPrefix(roleName, courseGroupName+"-cg-")
+}

--- a/servers/core/keycloakRealmManager/deletingCourse_test.go
+++ b/servers/core/keycloakRealmManager/deletingCourse_test.go
@@ -1,0 +1,28 @@
+package keycloakRealmManager
+
+import "testing"
+
+func TestIsCourseClientRole(t *testing.T) {
+	const group = "ws24-ios"
+	cases := []struct {
+		name     string
+		roleName string
+		want     bool
+	}{
+		{"lecturer role", group + "-Lecturer", true},
+		{"editor role", group + "-Editor", true},
+		{"custom group role", group + "-cg-teamA", true},
+		{"unrelated role", "PromptAdmin", false},
+		{"other course lecturer", "ws24-android-Lecturer", false},
+		{"prefix course is not matched", "ws24-ios-advanced-Lecturer", false},
+		{"prefix course custom role is not matched", "ws24-ios-advanced-cg-teamA", false},
+		{"bare group name", group, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCourseClientRole(tc.roleName, group); got != tc.want {
+				t.Errorf("isCourseClientRole(%q, %q) = %v, want %v", tc.roleName, group, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Deleting a course now also removes the Keycloak artifacts that were created for it. `CreateCourseGroupsAndRoles` builds a course group (`{semester}-{name}`) with `Lecturer`/`Editor` subgroups and the matching client roles, plus custom-group roles (`{group}-cg-{name}`), but none of these were ever cleaned up, so deleted courses left orphaned groups and roles behind in the realm.

`DeleteCourse` now calls a new `keycloakRealmManager.DeleteCourseGroupsAndRoles`, which:

- deletes the course group (Keycloak cascades its subgroups and group-role mappings), and
- deletes the course's client roles: the exact `-Lecturer`/`-Editor` staff roles plus any `-cg-` custom-group roles.

The Keycloak cleanup runs **before** the DB row is removed (the group name is derived from the course record) and is idempotent: a group that is already gone is treated as success. If cleanup fails, the course is kept so it stays deletable on a later retry instead of half-deleting.

## 📌 Reason for the change / Link to issue

Closes #184. Course deletion previously removed only the database rows, leaving the associated Keycloak roles and groups in place forever.

## 🧪 How to Test

1. Create a course, then delete it (as a `PromptAdmin`).
2. In the Keycloak admin console, confirm the `Prompt/{semester}-{name}` group (and its `Lecturer`/`Editor`/`CustomGroups` subgroups) is gone.
3. Confirm the `{semester}-{name}-Lecturer`, `-Editor`, and any `-cg-*` client roles are gone.
4. Automated: `cd servers/core && go test ./course/ ./keycloakRealmManager/`. `TestIsCourseClientRole` covers the role-matching logic, including that a course whose name is a prefix of another's is not caught by mistake.

## 🖼️ Screenshots (if UI changes are included)

<!-- No UI changes. -->

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
