### PR TITLE
`Interview`: link to the full application from the interviewee card

### DIFF
--- a/clients/interview_component/src/interview/components/StudentCard.tsx
+++ b/clients/interview_component/src/interview/components/StudentCard.tsx
@@ -3,11 +3,13 @@ import {
   getGravatarUrl,
   getStatusColor,
   getStudyDegreeString,
+  useCourseStore,
 } from '@tumaet/prompt-shared-state'
 import {
   Avatar,
   AvatarFallback,
   AvatarImage,
+  Button,
   Card,
   CardContent,
   CardHeader,
@@ -15,7 +17,17 @@ import {
   Separator,
 } from '@tumaet/prompt-ui-components'
 import { format } from 'date-fns'
-import { BookOpen, Calendar, Clock, FileUserIcon, GraduationCap, MapPin, Mic } from 'lucide-react'
+import {
+  BookOpen,
+  Calendar,
+  Clock,
+  ExternalLink,
+  FileUserIcon,
+  GraduationCap,
+  MapPin,
+  Mic,
+} from 'lucide-react'
+import { useNavigate, useParams } from 'react-router-dom'
 
 interface InterviewSlotData {
   id: string
@@ -30,8 +42,20 @@ interface StudentCardProps {
 }
 
 export function StudentCard({ participation, interviewSlot }: StudentCardProps) {
+  const navigate = useNavigate()
+  const { courseId } = useParams<{ courseId: string }>()
+  const { courses } = useCourseStore()
+
   const assessmentScore = participation.prevData?.score ?? 'N/A'
   const interviewScore = participation.restrictedData?.score ?? 'N/A'
+
+  const applicationPhaseId = courses
+    .find((c) => c.id === courseId)
+    ?.coursePhases.find((p) => p.coursePhaseType === 'Application')?.id
+  const applicationLink =
+    courseId && applicationPhaseId && participation.courseParticipationID
+      ? `/management/course/${courseId}/${applicationPhaseId}/participants/${participation.courseParticipationID}`
+      : undefined
 
   return (
     <Card className='h-full relative overflow-hidden'>
@@ -118,6 +142,24 @@ export function StudentCard({ participation, interviewSlot }: StudentCardProps) 
             </div>
           </div>
         </div>
+
+        {applicationLink && (
+          <>
+            <Separator />
+            <Button
+              variant='outline'
+              size='sm'
+              className='w-full'
+              onClick={(e) => {
+                e.stopPropagation()
+                navigate(applicationLink)
+              }}
+            >
+              <ExternalLink className='h-4 w-4 mr-2' />
+              View full application
+            </Button>
+          </>
+        )}
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Adds a **"View full application"** action to the interviewee card (`StudentCard`). It deep-links to the applicant's participant detail in the course's **Application** phase (`/management/course/<courseId>/<applicationPhaseId>/participants/<participationId>`).

The target Application phase is resolved from the course store; the action is hidden when the course has no Application phase. On the overview grid the click is stopped from bubbling so it doesn't also open the interview detail.

## 📌 Reason for the change / Link to issue

Interviewers wanted more context (full application, previous courses, …) from the interviewee card. The linked application detail page already renders the full application answers **and** the student's previous-course enrollments, so a single link surfaces that context without duplicating it here.

Note: showing previous-course enrollments *inline* in the interview card is intentionally **not** part of this PR. The only enrollments endpoint (`/api/students/:id/enrollments`) requires the instance-wide `PROMPT_Lecturer`/admin role, so a regular course lecturer gets a 403; doing it inline for them would need a new phase-scoped backend endpoint. That is left as a follow-up.

Part of #1199

## 🧪 How to Test

1. Open a course that has both an **Application** and an **Interview** phase.
2. Go to the Interview phase → **Manage** (overview grid) as an admin or course lecturer.
3. On any interviewee card, click **View full application** → you land on that applicant's application detail page (full answers + previous courses).
4. Open an interviewee's detail view; the same action is available on the card there.
5. On a course with no Application phase, the action is not shown.

## 🖼️ Screenshots (if UI changes are included)

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
