### PR TITLE
`Testing`: Add example phase module e2e coverage

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -81,6 +81,10 @@ services:
         condition: service_started
       client-assessment:
         condition: service_started
+      server-example:
+        condition: service_started
+      client-example:
+        condition: service_started
       client-matching:
         condition: service_started
       server-interview:
@@ -197,6 +201,74 @@ services:
           "CMD-SHELL",
           "pg_isready -d ${DB_SELF_TEAM_ALLOCATION_NAME} -U ${DB_SELF_TEAM_ALLOCATION_USER}",
         ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ── Example phase module (server + MF remote + own DB) ───────────────────
+  # Minimal placeholder phase; wired in as the canonical "new phase" example.
+  # Follows the blueprint in e2e/README.md ("Phase modules in the e2e stack").
+  server-example:
+    build:
+      context: ./servers/example_server
+      dockerfile: ../Dockerfile
+    container_name: prompt-e2e-server-example
+    depends_on:
+      db-example:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+    # No host port: reached only through the client-core nginx proxy.
+    environment:
+      - CORE_HOST
+      - SERVER_CORE_HOST
+      - SERVER_ADDRESS
+      - SSL_MODE
+      # The service reads generic DB_USER/DB_PASSWORD/DB_NAME but
+      # service-specific host/port vars.
+      - DB_USER=${DB_EXAMPLE_USER}
+      - DB_PASSWORD=${DB_EXAMPLE_PASSWORD}
+      - DB_NAME=${DB_EXAMPLE_NAME}
+      - DB_HOST_EXAMPLE_SERVER=${DB_EXAMPLE_HOST}
+      - DB_PORT_EXAMPLE_SERVER=${DB_EXAMPLE_PORT}
+      - KEYCLOAK_HOST
+      - KEYCLOAK_REALM_NAME
+      - DEBUG
+    # Distroless image (no shell/wget), so no container healthcheck.
+    # Readiness is polled by the runner's global-setup via
+    # /example-service/api/info through the client-core proxy.
+
+  client-example:
+    build:
+      context: ./clients/example_component
+      dockerfile: Dockerfile
+      args: *client-build-args
+      additional_contexts: *client-additional-contexts
+    container_name: prompt-e2e-client-example
+    depends_on:
+      - clients-base
+    # No host port: the remote is served through the client-core nginx proxy
+    # at /example/ (prefix stripped, like Traefik in prod).
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:80/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  db-example:
+    image: "postgres:15.18-alpine"
+    container_name: prompt-e2e-db-example
+    environment:
+      - POSTGRES_USER=${DB_EXAMPLE_USER}
+      - POSTGRES_PASSWORD=${DB_EXAMPLE_PASSWORD}
+      - POSTGRES_DB=${DB_EXAMPLE_NAME}
+      - TZ=Europe/Berlin
+    # No seed: the phase server runs its own migrations on the empty DB and
+    # the tests create all phase data themselves.
+    healthcheck:
+      test:
+        ["CMD-SHELL", "pg_isready -d ${DB_EXAMPLE_NAME} -U ${DB_EXAMPLE_USER}"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -706,6 +778,11 @@ services:
         condition: service_healthy
       server-assessment:
         # distroless; global-setup polls /assessment/api/info.
+        condition: service_started
+      client-example:
+        condition: service_healthy
+      server-example:
+        # distroless; global-setup polls /example-service/api/info.
         condition: service_started
       client-matching:
         condition: service_healthy

--- a/e2e/.env.e2e
+++ b/e2e/.env.e2e
@@ -87,6 +87,13 @@ DB_TEAM_ALLOCATION_NAME=prompt
 DB_TEAM_ALLOCATION_USER=prompt-postgres
 DB_TEAM_ALLOCATION_PASSWORD=prompt-postgres
 
+# ─── Example database ────────────────────────────────────────────────────────
+DB_EXAMPLE_HOST=db-example
+DB_EXAMPLE_PORT=5432
+DB_EXAMPLE_NAME=prompt
+DB_EXAMPLE_USER=prompt-postgres
+DB_EXAMPLE_PASSWORD=prompt-postgres
+
 # ─── Micro-frontend hosts (referenced by the core client's env.js) ──────────
 # Empty = same-origin: the component's API calls go to the browser origin
 # (client-core) and are proxied to the phase server by e2e/nginx/client-core.conf.
@@ -95,10 +102,10 @@ ASSESSMENT_HOST=
 INTERVIEW_HOST=
 CERTIFICATE_HOST=
 TEAM_ALLOCATION_HOST=
+EXAMPLE_HOST=
 # The remaining modules are not part of the e2e stack (yet).
 INTRO_COURSE_HOST=http://localhost:8082
 DEVOPS_CHALLENGE_HOST=http://localhost:9010
-EXAMPLE_HOST=http://localhost:8086
 
 # ─── S3 (SeaweedFS) ─────────────────────────────────────────────────────────
 S3_BUCKET=prompt-files

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,8 +2,9 @@
 
 Black-box e2e tests that boot the **core server + core client + Keycloak +
 Postgres + SeaweedFS** in Docker — plus the **self team allocation**,
-**assessment**, **interview**, **certificate**, and **team allocation phase
-modules** (Go service, own Postgres, Module Federation remote each) and the
+**assessment**, **example**, **interview**, **certificate**, and **team
+allocation phase modules** (Go service, own Postgres, Module Federation remote
+each) and the
 **matching module** (Module Federation remote only; its backend is core-hosted)
 — and drive them like a real user, with
 [Playwright](https://playwright.dev). They catch full-stack regressions (auth
@@ -89,6 +90,11 @@ docker-compose.e2e.yml
  │    │                      migrations also create the default schemas)
  │    ├── server-assessment  built from ../servers/assessment
  │    └── client-assessment  the Module Federation remote (nginx)
+ ├── example phase module:
+ │    ├── db-example      own ephemeral Postgres (empty; the server runs its
+ │    │                   own migrations on startup)
+ │    ├── server-example  built from ../servers/example_server
+ │    └── client-example  the Module Federation remote (nginx)
  ├── matching module:
  │    └── client-matching    the Module Federation remote (nginx); no server or
  │                           DB — its backend is core-hosted (server-core)

--- a/e2e/nginx/client-core.conf
+++ b/e2e/nginx/client-core.conf
@@ -60,6 +60,16 @@ server {
     proxy_pass http://client-team-allocation/;
   }
 
+  # The example server groups its routes under /example-service/api, but the MF
+  # remote is served at /example (core loads /example/remoteEntry.js).
+  location /example-service/api/ {
+    proxy_pass http://server-example:8080;
+  }
+
+  location /example/ {
+    proxy_pass http://client-example/;
+  }
+
   location / {
     gzip_static on;
     root   /usr/share/nginx/html;

--- a/e2e/seed/e2e_seed.sql
+++ b/e2e/seed/e2e_seed.sql
@@ -740,7 +740,10 @@ INSERT INTO public.course_phase_participation (course_participation_id, course_p
 --
 
 INSERT INTO public.course_phase_type VALUES ('a1111111-1111-1111-1111-111111111111', 'Application', true, 'core', 'Application collection phase');
-INSERT INTO public.course_phase_type VALUES ('a2222222-2222-2222-2222-222222222222', 'Example', false, 'example', 'Example phase');
+-- Name matches the core client's PhaseRouter key (example_component) so the
+-- Module Federation remote renders; base URL matches the e2e nginx proxy
+-- (/example-service/api → server-example) so core can resolve its info/copy/config.
+INSERT INTO public.course_phase_type VALUES ('a2222222-2222-2222-2222-222222222222', 'example_component', false, '{CORE_HOST}/example-service/api', 'Example phase');
 -- Fixed UUIDs so seeded course phases can reference these types deterministically; the
 -- core server's startup init matches by name and skips creating them (it would
 -- otherwise use random UUIDs). {CORE_HOST} is replaced by core at read time.
@@ -814,6 +817,16 @@ INSERT INTO public.course_phase VALUES ('d0000006-0000-0000-0000-000000000006', 
 INSERT INTO public.course_phase VALUES ('d0000007-0000-0000-0000-000000000007', 'c0000001-0000-0000-0000-000000000001', 'Assessment Self Evaluation', '{}', false, 'b4444444-4444-4444-4444-444444444444', '{}');
 INSERT INTO public.course_phase VALUES ('d0000008-0000-0000-0000-000000000008', 'be780b32-a678-4b79-ae1c-80071771d254', 'Assessment', '{}', false, 'b4444444-4444-4444-4444-444444444444', '{}');
 INSERT INTO public.course_phase VALUES ('d0000009-0000-0000-0000-000000000009', 'c0000001-0000-0000-0000-000000000001', 'Assessment Print', '{}', false, 'b4444444-4444-4444-4444-444444444444', '{}');
+
+--
+-- Standalone Example phases (no graph edges, route by URL). The example phase is
+-- a minimal placeholder module, so it needs no participants or config:
+-- d000000f = MF smoke + lecturer-info API auth on iPraktikumFull,
+-- d0000010 = TestCourse negative-auth fixture (course-lecturer of iPraktikumFull
+-- is not a lecturer of TestCourse, so its info endpoint must reject them).
+--
+INSERT INTO public.course_phase VALUES ('d000000f-0000-0000-0000-00000000000f', 'c0000001-0000-0000-0000-000000000001', 'Example', '{}', false, 'a2222222-2222-2222-2222-222222222222', '{}');
+INSERT INTO public.course_phase VALUES ('d0000010-0000-0000-0000-000000000010', 'be780b32-a678-4b79-ae1c-80071771d254', 'Example', '{}', false, 'a2222222-2222-2222-2222-222222222222', '{}');
 
 --
 -- Standalone Matching phase (no graph edge) owned by the matching lecturer

--- a/e2e/src/data/constants.ts
+++ b/e2e/src/data/constants.ts
@@ -180,6 +180,16 @@ export const FULL_COURSE_ROLES = {
   editor: 'ios2425-iPraktikumFull-Editor',
 }
 
+// Standalone Example phase on fullCourse (no graph edge, navigate by URL). The
+// example phase is a minimal placeholder module: it hosts the module-federation
+// smoke test and the lecturer-only info API-auth read.
+export const EXAMPLE_PHASE_ID = 'd000000f-0000-0000-0000-00000000000f'
+
+// Example phase on TestCourse: the e2e course-lecturer holds a role scoped to
+// iPraktikumFull only, so its info endpoint must reject them (negative auth
+// fixture).
+export const EXAMPLE_FOREIGN_PHASE_ID = 'd0000010-0000-0000-0000-000000000010'
+
 // CLOSED Application phase on TestCourse (applicationEndDate in the past):
 // the public apply endpoints must reject it (GET 404, POST 400).
 export const CLOSED_APPLICATION_PHASE_ID = 'aaaa5555-0000-0000-0000-0000000000a5'

--- a/e2e/src/env.ts
+++ b/e2e/src/env.ts
@@ -19,6 +19,7 @@ export const ASSESSMENT_API = '/assessment/api'
 export const INTERVIEW_API = '/interview/api'
 export const CERTIFICATE_API = '/certificate/api'
 export const TEAM_ALLOCATION_API = '/team-allocation/api'
+export const EXAMPLE_API = '/example-service/api'
 
 export const tokenEndpoint = () =>
   `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`

--- a/e2e/src/global-setup.ts
+++ b/e2e/src/global-setup.ts
@@ -9,6 +9,7 @@ import {
   BASE_URL,
   CERTIFICATE_API,
   CORE_API_URL,
+  EXAMPLE_API,
   INTERVIEW_API,
   SELF_TEAM_ALLOCATION_API,
   TEAM_ALLOCATION_API,
@@ -90,6 +91,7 @@ export default async function globalSetup(_config: FullConfig) {
     'self-team-allocation',
   )
   await waitForServiceInfo(`${BASE_URL}${ASSESSMENT_API}/info`, 'assessment')
+  await waitForServiceInfo(`${BASE_URL}${EXAMPLE_API}/info`, 'example-service')
   await waitForServiceInfo(`${BASE_URL}${INTERVIEW_API}/info`, 'interview')
   await waitForServiceInfo(`${BASE_URL}${CERTIFICATE_API}/info`, 'certificate')
   await waitForServiceInfo(`${BASE_URL}${TEAM_ALLOCATION_API}/info`, 'team-allocation')

--- a/e2e/src/pages/ExamplePage.ts
+++ b/e2e/src/pages/ExamplePage.ts
@@ -1,0 +1,21 @@
+import { Page, Locator, expect } from '@playwright/test'
+
+// /management/course/:courseId/:phaseId — the Example remote (Module Federation)
+// rendered inside the core shell. The example phase is a minimal placeholder,
+// so its overview only shows a static "Example Component" card (the title is a
+// shadcn CardTitle <div>, not a heading element, so match it by text).
+export class ExamplePage {
+  readonly title: Locator
+
+  constructor(private readonly page: Page) {
+    this.title = this.page.getByText('Example Component', { exact: true })
+  }
+
+  async goto(courseId: string, phaseId: string) {
+    await this.page.goto(`/management/course/${courseId}/${phaseId}`)
+  }
+
+  async expectLoaded() {
+    await expect(this.title).toBeVisible({ timeout: 15_000 })
+  }
+}

--- a/e2e/tests/api/example.api.spec.ts
+++ b/e2e/tests/api/example.api.spec.ts
@@ -1,0 +1,51 @@
+import { request } from '@playwright/test'
+import { test, expect } from '../../src/fixtures/api'
+import { BASE_URL, EXAMPLE_API } from '../../src/env'
+import { EXAMPLE_FOREIGN_PHASE_ID, EXAMPLE_PHASE_ID } from '../../src/data/constants'
+
+// The example server is reached on the browser origin through the e2e nginx
+// proxy (same path prefix as prod Traefik). Its /info read requires admin or a
+// course-scoped lecturer; prompt-sdk auth answers 401 both for missing tokens
+// and for valid tokens lacking the required role.
+const phaseUrl = (phaseId: string, path: string) =>
+  `${BASE_URL}${EXAMPLE_API}/course_phase/${phaseId}/${path}`
+
+test.describe('example API auth', () => {
+  test('rejects unauthenticated requests', async () => {
+    const anon = await request.newContext()
+    try {
+      const res = await anon.get(phaseUrl(EXAMPLE_PHASE_ID, 'info'))
+      expect(res.status()).toBe(401)
+    } finally {
+      await anon.dispose()
+    }
+  })
+
+  test('rejects a student on the lecturer-only info endpoint', async ({ apiAs }) => {
+    const api = await apiAs('student')
+    const res = await api.get(phaseUrl(EXAMPLE_PHASE_ID, 'info'))
+    expect(res.status()).toBe(401)
+  })
+
+  test('rejects a global (non-course) lecturer', async ({ apiAs }) => {
+    // `lecturer` has PROMPT_Lecturer only; the endpoint requires admin or a
+    // course-scoped lecturer role.
+    const api = await apiAs('lecturer')
+    const res = await api.get(phaseUrl(EXAMPLE_PHASE_ID, 'info'))
+    expect(res.status()).toBe(401)
+  })
+
+  test('accepts a course lecturer', async ({ apiAs }) => {
+    const api = await apiAs('course-lecturer')
+    const res = await api.get(phaseUrl(EXAMPLE_PHASE_ID, 'info'))
+    expect(res.status()).toBe(200)
+  })
+
+  test('rejects a course lecturer on a phase of a course they do not lead', async ({
+    apiAs,
+  }) => {
+    const api = await apiAs('course-lecturer')
+    const res = await api.get(phaseUrl(EXAMPLE_FOREIGN_PHASE_ID, 'info'))
+    expect(res.status()).toBe(401)
+  })
+})

--- a/e2e/tests/api/example.api.spec.ts
+++ b/e2e/tests/api/example.api.spec.ts
@@ -27,14 +27,6 @@ test.describe('example API auth', () => {
     expect(res.status()).toBe(401)
   })
 
-  test('rejects a global (non-course) lecturer', async ({ apiAs }) => {
-    // `lecturer` has PROMPT_Lecturer only; the endpoint requires admin or a
-    // course-scoped lecturer role.
-    const api = await apiAs('lecturer')
-    const res = await api.get(phaseUrl(EXAMPLE_PHASE_ID, 'info'))
-    expect(res.status()).toBe(401)
-  })
-
   test('accepts a course lecturer', async ({ apiAs }) => {
     const api = await apiAs('course-lecturer')
     const res = await api.get(phaseUrl(EXAMPLE_PHASE_ID, 'info'))

--- a/e2e/tests/example/mf-smoke.spec.ts
+++ b/e2e/tests/example/mf-smoke.spec.ts
@@ -1,0 +1,17 @@
+import { test } from '../../src/fixtures/auth'
+import { ExamplePage } from '../../src/pages/ExamplePage'
+import { SEEDED_COURSES, EXAMPLE_PHASE_ID } from '../../src/data/constants'
+
+// Module Federation smoke test: the phase page is rendered by the
+// example_component REMOTE, loaded by the core shell from
+// /example/remoteEntry.js through the e2e nginx proxy. If the remote fails to
+// load, the shell renders a LoadingError instead of the heading.
+test.use({ role: 'course-lecturer' })
+
+test.describe('example: module federation smoke', () => {
+  test('the remote loads and renders inside the core shell', async ({ page }) => {
+    const phase = new ExamplePage(page)
+    await phase.goto(SEEDED_COURSES.fullCourse.id, EXAMPLE_PHASE_ID)
+    await phase.expectLoaded()
+  })
+})


### PR DESCRIPTION
# 📝 Pull Request Template

Use this template to provide all necessary information for reviewing and testing your changes.

## ✨ What is the change?

Adds end-to-end coverage for the **example phase module**, following the self-team-allocation / assessment blueprint (#1811):

- **e2e stack** (`docker-compose.e2e.yml`): new `server-example`, `client-example`, and `db-example` (own ephemeral Postgres) services, wired into `client-core` and `e2e-runner` `depends_on`. `e2e/.env.e2e` gains the `DB_EXAMPLE_*` block and sets `EXAMPLE_HOST` empty (same-origin, proxied like the other in-stack modules).
- **Routing** (`e2e/nginx/client-core.conf`): `/example-service/api/` → `server-example`, `/example/` → `client-example` remote (mirrors prod Traefik).
- **Seed** (`e2e/seed/e2e_seed.sql`): renames the `Example` phase type to `example_component` (the core `PhaseRouter` key) with the proper `{CORE_HOST}/example-service/api` resolution URL, and adds a standalone example phase on `iPraktikumFull` plus a `TestCourse` negative-auth fixture.
- **Readiness**: `global-setup` polls `/example-service/api/info`; `env.ts` / `constants.ts` expose the new API prefix and phase IDs.
- **Specs**:
  - `tests/example/mf-smoke.spec.ts` — the example remote loads and renders inside the core shell as a lecturer.
  - `tests/api/example.api.spec.ts` — the lecturer-only `/info` endpoint rejects unauthenticated requests and a student; accepts a course lecturer; and rejects a lecturer of a different course.

The example phase is a minimal placeholder module (no real CRUD), so the coverage is the module-boot + MF render + API auth matrix rather than the "template CRUD" wording of the original issue, which predates the `template` → `example` rename.

Note: prompt-sdk grants a global `PROMPT_Lecturer` access to `CourseLecturer`-gated endpoints (verified: `/info` returns 200 for that role), so there is no "global lecturer is rejected" case — the wrong-role and cross-course rejections are covered by the student and foreign-course-lecturer cases.

Verified locally: `example-service ready (via proxy)` in global-setup, and all 5 example specs (MF smoke + 4 API-auth) pass against the e2e stack.

## 📌 Reason for the change / Link to issue

Closes #1821. The example phase had no e2e coverage and was not part of the e2e stack. Depends on the stack scaffolding from #1810 / #1811 (merged).

## 🧪 How to Test

1. `make test-e2e` — the example server/client/db boot, `global-setup` reports `example-service ready (via proxy)`, and the `example` MF-smoke + `example.api` auth specs pass alongside the existing suites.
2. `make test-e2e-ui` to step through `tests/example/` interactively.
3. `cd e2e && npm install && npm run typecheck` passes (pre-existing tsconfig deprecation warnings aside).

## 🖼️ Screenshots (if UI changes are included)

<!-- Include before/after screenshots if this PR involves any visual changes. -->

| Before         | After         |
| -------------- | ------------- |
| ![before](url) | ![after](url) |

## ✅ PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)

