### PR TITLE
`General`: Rewrite PR template so instructional text does not leak into PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,37 @@
-# 📝 Pull Request Template
+<!--
+  Fill in the sections below. Lines in HTML comments (like this one) are
+  invisible in the final PR — replace or delete them. See the PR guide:
+  docs/contributor/guide/pull_requests.md
+-->
 
-Use this template to provide all necessary information for reviewing and testing your changes.
+## Summary
 
-## ✨ What is the change?
+<!-- One or two sentences: what does this PR do and why? -->
 
-<!-- Briefly describe what has been changed or added in this PR. -->
+## Details
 
-## 📌 Reason for the change / Link to issue
+<!-- What changed or was added. -->
 
-<!-- Explain why this change was made. Optionally include a link to the relevant issue or ticket. -->
+## Reason / Link to issue
 
-## 🧪 How to Test
+<!-- Why this change was made. Reference the issue, e.g. "Closes #123". -->
 
-<!-- List the steps someone should follow to test this PR. -->
+## How to Test
 
+<!-- Steps to verify. Delete this section if not applicable.
 1. Step 1
 2. Step 2
-3. ...
+-->
 
-## 🖼️ Screenshots (if UI changes are included)
+## Screenshots
 
-<!-- Include before/after screenshots if this PR involves any visual changes. -->
-
+<!-- For UI changes only — delete this section otherwise.
 | Before         | After         |
 | -------------- | ------------- |
 | ![before](url) | ![after](url) |
+-->
 
-## ✅ PR Checklist
+## PR Checklist
 
 - [ ] Tested locally or on the dev environment
 - [ ] Code is clean, readable, and documented


### PR DESCRIPTION
## Summary

Rewrites `.github/pull_request_template.md` so that instructional and placeholder
text no longer ends up as real content in every opened PR, and adds an explicit
`Summary` field.

## Details

The old template mixed two kinds of text: field prompts written as HTML comments
(which authors correctly replace) and instructional/placeholder text written as
plain markdown. Because the plain-markdown parts render as visible content, they
were rarely deleted — every PR carried the `# 📝 Pull Request Template` heading,
the `Use this template…` sentence, the `Step 1 / Step 2` list, and the dummy
`![before](url)` screenshot table, even on non-UI changes.

This rewrite:

- Removes the redundant `# 📝 Pull Request Template` H1 and intro sentence (the PR
  already has a title); the how-to instructions now live in a leading HTML comment
  pointing at `docs/contributor/guide/pull_requests.md`.
- Adds a dedicated `Summary` section for a one/two-sentence TL;DR.
- Moves the remaining placeholders (test steps, screenshot table) inside HTML
  comments so unfilled sections render empty instead of as dummy text.
- Keeps all real section headings and the checklist unchanged.

## Reason / Link to issue

Opened PRs consistently carried leftover template boilerplate in their bodies
because the meta-text was plain markdown rather than HTML comments. Making the
instructional text invisible keeps PR descriptions clean and nudges authors to
provide a real summary.

## How to Test

1. Open a new PR on any branch; confirm the description no longer pre-fills the
   `📝 Pull Request Template` heading or the before/after screenshot table.
2. Leave a section untouched and confirm it renders empty rather than as
   placeholder text.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
