### PR TITLE
`Application`: Suggest a default access key when exporting a question

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationQuestionConfigPage/FormPages/FormFields/ExportSettingsFields.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationQuestionConfigPage/FormPages/FormFields/ExportSettingsFields.tsx
@@ -18,6 +18,14 @@ interface ExportSettingsFieldsProps {
   onCsvExportEnabledChange: (checked: boolean) => void
 }
 
+const suggestAccessKey = (title: string): string =>
+  title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 50)
+
 export const ExportSettingsFields = ({
   form,
   csvExportEnabled,
@@ -63,7 +71,18 @@ export const ExportSettingsFields = ({
                 checked={!!field.value}
                 onCheckedChange={(checked) => {
                   field.onChange(checked)
-                  if (!checked) {
+                  if (checked) {
+                    const currentKey = form.getValues('accessKey')
+                    if (!currentKey || currentKey.trim() === '') {
+                      const suggestion = suggestAccessKey(form.getValues('title') ?? '')
+                      if (suggestion) {
+                        form.setValue('accessKey', suggestion, {
+                          shouldValidate: true,
+                          shouldDirty: true,
+                        })
+                      }
+                    }
+                  } else {
                     form.setValue('accessKey', '')
                   }
                 }}


### PR DESCRIPTION
## Summary

When configuring an application question, enabling "Accessible for Other Phases" now suggests a default access key instead of leaving the field empty.

## Details

- In `ExportSettingsFields`, toggling "Accessible for Other Phases" on now prefills the Access Key with a suggestion derived from the question title (lowercased, runs of non-alphanumeric characters collapsed to `_`, trimmed, capped at 50 chars to match the column limit).
- The suggestion is only applied when the access key is currently empty, so an existing/edited key is never overwritten. The field stays fully editable.
- Turning the toggle off still clears the access key (unchanged behavior).

## Reason / Link to issue

Previously the access key started empty, forcing lecturers to invent a key by hand. Closes #174.

## How to Test

1. Open an Application phase → question configuration and add or edit a question with a title (e.g. "Motivation Letter").
2. Toggle "Accessible for Other Phases" on.
3. Verify the Access Key field is prefilled with a valid suggestion (e.g. `motivation_letter`) and is still editable.
4. Clear the key, toggle off and on again to confirm it re-suggests; set a custom key, toggle off/on, and confirm a non-empty key is not overwritten.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
