### PR TITLE
`Application`: Fix submit-success modal navigation and stop logging out on back

### DIFF
--- a/clients/core/src/publicPages/application/components/ApplicationSavingDialog.tsx
+++ b/clients/core/src/publicPages/application/components/ApplicationSavingDialog.tsx
@@ -14,6 +14,7 @@ interface ApplicationSavingDialogProps {
   showDialog: 'saving' | 'success' | 'error' | null
   onClose: () => void
   onNavigateBack: () => void
+  navigateBackLabel?: string
   errorMessage?: string
   confirmationMailSent?: boolean
 }
@@ -22,6 +23,7 @@ export const ApplicationSavingDialog = ({
   showDialog,
   onClose,
   onNavigateBack,
+  navigateBackLabel = 'Back to Overview',
   errorMessage,
   confirmationMailSent = false,
 }: ApplicationSavingDialogProps) => {
@@ -92,10 +94,8 @@ export const ApplicationSavingDialog = ({
   return (
     <Dialog
       open={isOpen}
-      onOpenChange={() => {
-        if (showDialog === 'success') {
-          onNavigateBack()
-        } else {
+      onOpenChange={(open) => {
+        if (!open) {
           onClose()
         }
       }}
@@ -125,7 +125,7 @@ export const ApplicationSavingDialog = ({
             </Button>
           ) : showDialog === 'success' ? (
             <Button onClick={onNavigateBack} className='w-full sm:w-auto'>
-              Back to Overview
+              {navigateBackLabel}
             </Button>
           ) : (
             <Button variant='outline' onClick={onClose} className='w-full sm:w-auto'>

--- a/clients/core/src/publicPages/application/pages/ApplicationAuthenticated/ApplicationAuthenticated.tsx
+++ b/clients/core/src/publicPages/application/pages/ApplicationAuthenticated/ApplicationAuthenticated.tsx
@@ -10,7 +10,7 @@ import { getApplicationFormWithDetails } from '@core/network/queries/application
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { type Student, useAuthStore } from '@tumaet/prompt-shared-state'
 import { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { AuthenticatedPageWrapper } from '../../../shared/components/AuthenticatedPageWrapper'
 import { ApplicationHeader } from '../../components/ApplicationHeader'
 import { ApplicationSavingDialog } from '../../components/ApplicationSavingDialog'
@@ -21,7 +21,8 @@ import { InfoBanner } from './components/InfoBanner'
 
 export const ApplicationAuthenticated = () => {
   const { phaseId } = useParams<{ phaseId: string }>()
-  const { user, logout } = useAuthStore()
+  const { user } = useAuthStore()
+  const navigate = useNavigate()
   const [showDialog, setShowDialog] = useState<'saving' | 'success' | 'error' | null>(null)
   const queryClient = useQueryClient()
   const [confirmationMailSent, setConfirmationMailSent] = useState<boolean>(false)
@@ -83,7 +84,11 @@ export const ApplicationAuthenticated = () => {
   }
 
   const handleBack = () => {
-    logout()
+    navigate('/')
+  }
+
+  const handleGoToManagement = () => {
+    navigate('/management/courses')
   }
 
   if (isPending || isApplicationPending) {
@@ -153,7 +158,8 @@ export const ApplicationAuthenticated = () => {
       <ApplicationSavingDialog
         showDialog={showDialog}
         onClose={handleCloseDialog}
-        onNavigateBack={handleBack}
+        onNavigateBack={handleGoToManagement}
+        navigateBackLabel='Go to App'
         errorMessage={mutateError?.message}
         confirmationMailSent={confirmationMailSent}
       />


### PR DESCRIPTION
## Summary

Fixes the broken application submit flow: finishing or closing the success modal no longer logs the user out, and there is now a clear, working way into the management view and back to the application site.

## Details

In `ApplicationAuthenticated` the "back"/success actions previously called `logout()`, which hit the Keycloak logout endpoint and returned the user to the apply site logged out. This PR removes that:

- **Success modal button** now routes to the management view (`/management/courses`) and is labelled **"Go to App"**, instead of calling `logout()`.
- **Closing the success modal** (X / overlay / Esc) now simply closes it (`ApplicationSavingDialog` `onOpenChange` always calls `onClose`), instead of logging out and returning to the apply site.
- **Application header "Back to Overview"** now navigates back to the application site landing (`/`) instead of logging out.
- `ApplicationSavingDialog` gained an optional `navigateBackLabel` (defaults to "Back to Overview", so the external/unauthenticated flow is unchanged).

Because the flow no longer destroys the Keycloak session, the header **"Go to App"** entry stays visible and usable after submitting (it is shown whenever a user is logged in), and switching to the management view no longer forces a re-login.

## Reason / Link to issue

Closes #1725.

Partially addresses #1724: the forced re-login when moving between apply and management is removed (the session is no longer destroyed). The remaining redirect round-trip on switching is caused by a separate Keycloak initialization/persistence bug and will be fixed in a dedicated follow-up PR.

## How to Test

1. Open an application phase's authenticated form (`/apply/:phaseId/authenticated`) while logged in.
2. Fill in and submit the application → the "Application Saved" dialog appears.
3. Click **Go to App** → you land on `/management/courses` and are still logged in (no logout, no credential prompt).
4. Submit again and this time close the dialog via the X / clicking outside / Esc → the dialog just closes and you stay on the form, still logged in.
5. Click the header **Back to Overview** → you return to the application site landing without being logged out. The header still shows a **Go to App** entry.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
