### PR TITLE
`UI/UX`: Add dark mode support to the public application pages

### DIFF
--- a/clients/core/src/publicPages/application/pages/ApplicationForm/components/TextForm/ApplicationQuestionTextForm.tsx
+++ b/clients/core/src/publicPages/application/pages/ApplicationForm/components/TextForm/ApplicationQuestionTextForm.tsx
@@ -94,7 +94,7 @@ export const ApplicationQuestionTextForm = forwardRef(function ApplicationQuesti
                       disabled={isInstructorView}
                     />
                   )}
-                  <div className='absolute right-2 bottom-2 text-sm text-gray-500'>
+                  <div className='absolute right-2 bottom-2 text-sm text-muted-foreground'>
                     {charCount}/{question.allowedLength || 255}
                   </div>
                 </div>

--- a/clients/core/src/publicPages/landingPage/LandingPage.tsx
+++ b/clients/core/src/publicPages/landingPage/LandingPage.tsx
@@ -19,17 +19,17 @@ export function LandingPage() {
   return (
     <NonAuthenticatedPageWrapper>
       <section className='text-center mb-16'>
-        <h2 className='text-2xl font-bold text-gray-900 sm:text-3xl lg:text-4xl mb-4'>
+        <h2 className='text-2xl font-bold text-foreground sm:text-3xl lg:text-4xl mb-4'>
           Course Application Portal
         </h2>
-        <p className='text-xl text-gray-600 max-w-4xl mx-auto mb-8'>
+        <p className='text-xl text-muted-foreground max-w-4xl mx-auto mb-8'>
           Welcome! You’ll find all courses currently open for applications below—you can apply by
           selecting the course you are interested in.
         </p>
       </section>
 
       <section className='mb-16'>
-        <h3 className='text-2xl font-semibold text-gray-800 mb-6'>
+        <h3 className='text-2xl font-semibold text-foreground mb-6'>
           Available Courses for Application
         </h3>
         {isPending ? (

--- a/clients/core/src/publicPages/landingPage/components/CourseCard.tsx
+++ b/clients/core/src/publicPages/landingPage/components/CourseCard.tsx
@@ -49,16 +49,16 @@ export const CourseCard = ({ courseDetails }: CourseCardProps) => {
           <div className='p-3 space-y-4'>
             <div className='flex items-center space-x-2'>
               <Calendar className='h-4 w-4 shrink-0' />
-              <div className='flex gap-4 flex-1 text-sm font-medium text-gray-600'>
+              <div className='flex gap-4 flex-1 text-sm font-medium text-muted-foreground'>
                 <div className='flex-1'>
-                  <span className='font-semibold text-slate-600'>Course Start</span>
-                  <div className='text-slate-900'>
+                  <span className='font-semibold text-muted-foreground'>Course Start</span>
+                  <div className='text-foreground'>
                     {format(courseDetails.startDate, 'MMM d, yyyy')}
                   </div>
                 </div>
                 <div className='flex-1'>
-                  <span className='font-semibold text-slate-600'>Course End</span>
-                  <div className='text-slate-900'>
+                  <span className='font-semibold text-muted-foreground'>Course End</span>
+                  <div className='text-foreground'>
                     {format(courseDetails.endDate, 'MMM d, yyyy')}
                   </div>
                 </div>

--- a/clients/core/src/publicPages/landingPage/components/DeadlineInfo.tsx
+++ b/clients/core/src/publicPages/landingPage/components/DeadlineInfo.tsx
@@ -51,7 +51,7 @@ export const DeadlineInfo = ({ deadline }: { deadline: Date | string }) => {
   }
 
   return (
-    <div className={`space-y-1 ${isDeadlineClose ? 'text-red-600' : 'text-gray-600'}`}>
+    <div className={`space-y-1 ${isDeadlineClose ? 'text-red-600' : 'text-muted-foreground'}`}>
       <div className='flex items-center space-x-2'>
         <Clock className='h-4 w-4 shrink-0' />
         <p className='text-sm font-medium'>Apply by {formattedDeadline}</p>

--- a/clients/core/src/publicPages/legalPages/AboutPage.tsx
+++ b/clients/core/src/publicPages/legalPages/AboutPage.tsx
@@ -82,7 +82,7 @@ export default function AboutPage() {
           <Button
             variant='ghost'
             size='icon'
-            className='absolute left-4 top-4 hover:bg-gray-100 transition-colors'
+            className='absolute left-4 top-4 hover:bg-muted transition-colors'
             onClick={() => navigate(user ? '/management' : '/')}
             aria-label='Go back'
           >
@@ -96,14 +96,14 @@ export default function AboutPage() {
         <CardContent className='space-y-12'>
           <section>
             <h2 className='text-2xl font-semibold mb-4'>What is PROMPT?</h2>
-            <p className='text-gray-700 leading-relaxed'>
+            <p className='text-muted-foreground leading-relaxed'>
               PROMPT (Project-Oriented Modular Platform for Teaching) is a course management tool
               specifically designed for project-based university courses. By supporting a wide range
               of organizational processes, it reduces the administrative burden typically associated
               with such courses and aims to streamline the daily activities of both students and
               instructors, enhancing the overall learning experience.
             </p>
-            <p className='text-gray-700 leading-relaxed'>
+            <p className='text-muted-foreground leading-relaxed'>
               Originally developed for the iPraktikum at the Technical University of Munich, PROMPT
               has been reimagined with a flexible, modular architecture. Each course is built from
               independent, reusable components that can be easily extended, giving instructors the
@@ -135,12 +135,12 @@ export default function AboutPage() {
                 <a
                   key={index}
                   href={item.link}
-                  className='flex items-center p-3 rounded-lg bg-gray-50 hover:bg-gray-100 transition-colors'
+                  className='flex items-center p-3 rounded-lg bg-muted hover:bg-muted transition-colors'
                   target='_blank'
                   rel='noopener noreferrer'
                 >
                   <item.icon className='h-5 w-5 mr-3 text-blue-600' />
-                  <span className='text-gray-700 hover:text-gray-900'>{item.text}</span>
+                  <span className='text-muted-foreground hover:text-foreground'>{item.text}</span>
                 </a>
               ))}
             </div>
@@ -150,7 +150,7 @@ export default function AboutPage() {
 
           <section>
             <h2 className='text-2xl font-semibold mb-3'>Main Features</h2>
-            <p className='text-gray-700 leading-relaxed'>
+            <p className='text-muted-foreground leading-relaxed'>
               The core features are built-in functionalities essential for course management, while
               dynamically loaded phases are additional, customizable components that can be added as
               needed.
@@ -171,7 +171,7 @@ export default function AboutPage() {
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <p className='text-gray-700 text-sm'>{feature.description}</p>
+                    <p className='text-muted-foreground text-sm'>{feature.description}</p>
                   </CardContent>
                 </Card>
               ))}
@@ -193,7 +193,7 @@ export default function AboutPage() {
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <p className='text-gray-700 text-sm'>{phase.description}</p>
+                    <p className='text-muted-foreground text-sm'>{phase.description}</p>
                   </CardContent>
                 </Card>
               ))}
@@ -205,7 +205,7 @@ export default function AboutPage() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <p className='text-gray-700 text-sm'>
+                  <p className='text-muted-foreground text-sm'>
                     Easily extend PROMPT with custom phases tailored to your course needs.
                   </p>
                   <div className='flex justify-end mt-3'>
@@ -231,7 +231,7 @@ export default function AboutPage() {
 
           <section>
             <h2 className='text-2xl font-semibold mb-6'>Release Info</h2>
-            <ul className='list-disc list-inside text-gray-700'>
+            <ul className='list-disc list-inside text-muted-foreground'>
               <li>
                 <span className='font-semibold'>Github SHA:</span> {env.GITHUB_SHA}
               </li>

--- a/clients/core/src/publicPages/legalPages/components/ContributorList.tsx
+++ b/clients/core/src/publicPages/legalPages/components/ContributorList.tsx
@@ -72,7 +72,7 @@ export const ContributorList = () => {
                 >
                   {contributor.name}
                 </a>
-                <p className='text-sm text-gray-600 mt-1'>{contributor.contribution}</p>
+                <p className='text-sm text-muted-foreground mt-1'>{contributor.contribution}</p>
               </div>
             </CardContent>
           </Card>

--- a/clients/core/src/publicPages/shared/components/AuthenticatedPageWrapper.tsx
+++ b/clients/core/src/publicPages/shared/components/AuthenticatedPageWrapper.tsx
@@ -40,33 +40,35 @@ export const AuthenticatedPageWrapper = ({
     )
   }
   return (
-    <div className='min-h-screen flex flex-col'>
-      <main className='grow w-full px-4 sm:px-6 lg:px-8 py-12'>
-        <div className='max-w-[1400px] mx-auto'>
-          <Header withLoginButton={withLoginButton} onLogout={openLogoutDialog} />
-          {children}
-        </div>
-      </main>
-      <Footer />
-      {/** Dialog to confirm logout */}
-      <Dialog open={isLogoutDialogOpen} onOpenChange={setIsLogoutDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Confirm Logout</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to log out? You progress will NOT be saved.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant='outline' onClick={closeLogoutDialog}>
-              Cancel
-            </Button>
-            <Button variant='destructive' onClick={() => logout()}>
-              Logout
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    <DarkModeProvider>
+      <div className='min-h-screen bg-background text-foreground flex flex-col'>
+        <main className='grow w-full px-4 sm:px-6 lg:px-8 py-12'>
+          <div className='max-w-[1400px] mx-auto'>
+            <Header withLoginButton={withLoginButton} onLogout={openLogoutDialog} />
+            {children}
+          </div>
+        </main>
+        <Footer />
+        {/** Dialog to confirm logout */}
+        <Dialog open={isLogoutDialogOpen} onOpenChange={setIsLogoutDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Confirm Logout</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to log out? You progress will NOT be saved.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant='outline' onClick={closeLogoutDialog}>
+                Cancel
+              </Button>
+              <Button variant='destructive' onClick={() => logout()}>
+                Logout
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </DarkModeProvider>
   )
 }

--- a/clients/core/src/publicPages/shared/components/Footer.tsx
+++ b/clients/core/src/publicPages/shared/components/Footer.tsx
@@ -7,31 +7,31 @@ export const Footer = () => {
 
   return (
     <footer className='w-full mt-8 py-2 px-4 sm:px-6 lg:px-8 border-t border-gray-200 dark:border-gray-700 print:hidden'>
-      <div className='max-w-[1400px] mx-auto text-center text-sm text-gray-500'>
+      <div className='max-w-[1400px] mx-auto text-center text-sm text-muted-foreground'>
         <nav className='space-x-4'>
           <a
             href={`https://github.com/prompt-edu/prompt`}
             target='_blank'
-            className='text-gray-500 hover:text-gray-700 transition-colors underline'
+            className='text-muted-foreground hover:text-foreground transition-colors underline'
             rel='noreferrer'
           >
             v{version}
           </a>
           <a
             onClick={() => navigate('/about')}
-            className='text-gray-500 hover:text-gray-700 transition-colors underline cursor-pointer'
+            className='text-muted-foreground hover:text-foreground transition-colors underline cursor-pointer'
           >
             About
           </a>
           <a
             onClick={() => navigate('/imprint')}
-            className='text-gray-500 hover:text-gray-700 transition-colors underline cursor-pointer'
+            className='text-muted-foreground hover:text-foreground transition-colors underline cursor-pointer'
           >
             Imprint
           </a>
           <a
             onClick={() => navigate('/privacy')}
-            className='text-gray-500 hover:text-gray-700 transition-colors underline cursor-pointer'
+            className='text-muted-foreground hover:text-foreground transition-colors underline cursor-pointer'
           >
             Privacy Policy
           </a>

--- a/clients/core/src/publicPages/shared/components/Header.tsx
+++ b/clients/core/src/publicPages/shared/components/Header.tsx
@@ -1,6 +1,6 @@
 import { NavUserMenu } from '@managementConsole/layout/Sidebar/CourseSwitchSidebar/components/NavUserMenu'
 import { useAuthStore } from '@tumaet/prompt-shared-state'
-import { Button } from '@tumaet/prompt-ui-components'
+import { Button, ThemeToggle } from '@tumaet/prompt-ui-components'
 import { LogIn } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import packageJSON from '../../../../package.json'
@@ -23,32 +23,35 @@ export const Header = ({ withLoginButton = true, onLogout }: HeaderProps) => {
           <span className='text-2xl font-extrabold tracking-wide text-primary drop-shadow-xs'>
             PROMPT
           </span>
-          <span className='ml-1 text-s font-normal text-gray-400'>{version}</span>
+          <span className='ml-1 text-s font-normal text-muted-foreground'>{version}</span>
         </div>
       </div>
-      {withLoginButton && !user && (
-        <Button
-          variant='outline'
-          className='flex items-center space-x-2'
-          onClick={() => navigate('/management')}
-        >
-          <LogIn className='h-4 w-4' />
-          <span>Login</span>
-        </Button>
-      )}
-      {user && (
-        <div className='flex items-center gap-2'>
+      <div className='flex items-center gap-2'>
+        <ThemeToggle />
+        {withLoginButton && !user && (
           <Button
             variant='outline'
             className='flex items-center space-x-2'
             onClick={() => navigate('/management')}
           >
             <LogIn className='h-4 w-4' />
-            <span>Go to App</span>
+            <span>Login</span>
           </Button>
-          <NavUserMenu onLogout={onLogout ?? (() => {})} showThemeToggle={false} />
-        </div>
-      )}
+        )}
+        {user && (
+          <div className='flex items-center gap-2'>
+            <Button
+              variant='outline'
+              className='flex items-center space-x-2'
+              onClick={() => navigate('/management')}
+            >
+              <LogIn className='h-4 w-4' />
+              <span>Go to App</span>
+            </Button>
+            <NavUserMenu onLogout={onLogout ?? (() => {})} showThemeToggle={false} />
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/clients/core/src/publicPages/shared/components/NonAuthenticatedPageWrapper.tsx
+++ b/clients/core/src/publicPages/shared/components/NonAuthenticatedPageWrapper.tsx
@@ -1,6 +1,7 @@
 import { useAuthStore } from '@tumaet/prompt-shared-state'
 import {
   Button,
+  DarkModeProvider,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -8,7 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@tumaet/prompt-ui-components'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Footer } from './Footer'
 import { Header } from './Header'
 
@@ -24,36 +25,37 @@ export const NonAuthenticatedPageWrapper = ({
   const { logout } = useAuthStore()
   const [isLogoutDialogOpen, setIsLogoutDialogOpen] = useState(false)
 
-  useEffect(() => {
-    document.documentElement.classList.remove('dark')
-  }, [])
-
   return (
-    <div className='min-h-screen bg-white flex flex-col'>
-      <main className='grow w-full px-4 sm:px-6 lg:px-8 py-12'>
-        <div className='max-w-[1400px] mx-auto'>
-          <Header withLoginButton={withLoginButton} onLogout={() => setIsLogoutDialogOpen(true)} />
+    <DarkModeProvider>
+      <div className='min-h-screen bg-background text-foreground flex flex-col'>
+        <main className='grow w-full px-4 sm:px-6 lg:px-8 py-12'>
+          <div className='max-w-[1400px] mx-auto'>
+            <Header
+              withLoginButton={withLoginButton}
+              onLogout={() => setIsLogoutDialogOpen(true)}
+            />
 
-          {children}
-        </div>
-      </main>
-      <Footer />
-      <Dialog open={isLogoutDialogOpen} onOpenChange={setIsLogoutDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Confirm Logout</DialogTitle>
-            <DialogDescription>Are you sure you want to log out?</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant='outline' onClick={() => setIsLogoutDialogOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant='destructive' onClick={() => logout()}>
-              Logout
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+            {children}
+          </div>
+        </main>
+        <Footer />
+        <Dialog open={isLogoutDialogOpen} onOpenChange={setIsLogoutDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Confirm Logout</DialogTitle>
+              <DialogDescription>Are you sure you want to log out?</DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant='outline' onClick={() => setIsLogoutDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button variant='destructive' onClick={() => logout()}>
+                Logout
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </DarkModeProvider>
   )
 }


### PR DESCRIPTION
## Summary

Adds dark-mode support to the public application pages (application form, landing, legal), which previously always rendered in light mode unlike the rest of the app.

## Details

- `NonAuthenticatedPageWrapper` removed the `dark` class on mount and hardcoded a white background; it also lacked a `DarkModeProvider`. It now wraps its tree in `DarkModeProvider` (which defaults to the system theme) and uses `bg-background text-foreground`.
- `AuthenticatedPageWrapper` now wraps its main content (not just the loading state) in `DarkModeProvider` and uses theme tokens for the background.
- Added an always-visible `ThemeToggle` to the public header so applicants can switch light/dark/system.
- Replaced hardcoded light-only colors (`bg-white`, `text-gray-*`, `text-slate-*`) with theme tokens (`bg-background`, `bg-muted`, `text-foreground`, `text-muted-foreground`, `hover:*`) across the shared header/footer, landing page, about page, contributor list, and the application text-question form so they render correctly in dark mode. `InfoBanner` already had dark variants and was left as-is.

## Reason / Link to issue

Closes #1727.

## How to Test

1. Set your OS to dark mode (or use the new header theme toggle) and open a public application page (`/apply/:phaseId`), the landing page (`/`), and the About page.
2. Verify the background, text, header, and footer render in dark mode with readable contrast (no white boxes / black-on-dark text).
3. Toggle light/dark/system via the header toggle and confirm it switches immediately.
4. Confirm the management console still themes correctly (unchanged).

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
