### PR TITLE
`Core`: Fix responsive layout of the add application modal

### DIFF
--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationParticipantsPage/components/ApplicationManualAddingDialog/ApplicationManualAddingDialog.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationParticipantsPage/components/ApplicationManualAddingDialog/ApplicationManualAddingDialog.tsx
@@ -12,6 +12,7 @@ import {
   AlertDescription,
   AlertTitle,
   Button,
+  cn,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -45,6 +46,9 @@ export const ApplicationManualAddingDialog = ({
     universityAccount: false,
   })
   const [selectedStudent, setSelectedStudent] = useState<Student | null>(null)
+
+  // The type-selection step stays compact; the search table and application form steps are wider.
+  const isWideStep = state.page > 1
 
   const resetStates = useCallback(() => {
     setState({
@@ -179,7 +183,12 @@ export const ApplicationManualAddingDialog = ({
           Add Application
         </Button>
       </DialogTrigger>
-      <DialogContent className='sm:max-w-[900px] w-[90vw] max-h-[90vh]'>
+      <DialogContent
+        className={cn(
+          'w-[90vw] max-h-[90vh] overflow-y-auto [&>*]:min-w-0',
+          isWideStep && 'max-w-[900px]',
+        )}
+      >
         <DialogHeader>
           <DialogTitle>Add New Application</DialogTitle>
         </DialogHeader>

--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationParticipantsPage/components/ApplicationManualAddingDialog/components/StudentSearch.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationParticipantsPage/components/ApplicationManualAddingDialog/components/StudentSearch.tsx
@@ -8,7 +8,6 @@ import {
   Badge,
   Button,
   Input,
-  ScrollArea,
   Separator,
   Table,
   TableBody,
@@ -60,14 +59,15 @@ export const StudentSearch = ({ onSelect, existingApplications }: StudentSearchP
   return (
     <div className='space-y-4'>
       <h2 className='text-lg font-semibold'>Search Students Already Registered in Prompt</h2>
-      <form onSubmit={handleSearch} className='flex gap-2'>
+      <form onSubmit={handleSearch} className='flex flex-col gap-2 sm:flex-row'>
         <Input
           type='text'
+          className='min-w-0 flex-1'
           placeholder={`Enter a name, email, matriculation number, or ${translations.university['login-name']}`}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
         />
-        <Button type='submit' disabled={searchQuery.length <= 2}>
+        <Button type='submit' className='shrink-0' disabled={searchQuery.length <= 2}>
           <Search className='mr-2 h-4 w-4' />
           Search
         </Button>
@@ -82,7 +82,7 @@ export const StudentSearch = ({ onSelect, existingApplications }: StudentSearchP
           <AlertDescription>Failed to search university users. {error?.message}</AlertDescription>
         </Alert>
       ) : enteredSearchString.length > 0 && users && users.length > 0 ? (
-        <ScrollArea className='max-h-[calc(40vh-150px)]'>
+        <div className='max-h-[calc(40vh-150px)] w-full overflow-auto'>
           <Table>
             <TableHeader>
               <TableRow>
@@ -123,7 +123,7 @@ export const StudentSearch = ({ onSelect, existingApplications }: StudentSearchP
               ))}
             </TableBody>
           </Table>
-        </ScrollArea>
+        </div>
       ) : enteredSearchString.length > 0 ? (
         <Alert>
           <AlertTitle>No user found.</AlertTitle>

--- a/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationParticipantsPage/components/ApplicationManualAddingDialog/components/UniversitySelection.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/pages/ApplicationParticipantsPage/components/ApplicationManualAddingDialog/components/UniversitySelection.tsx
@@ -12,7 +12,7 @@ export const UniversitySelection = ({ setHasUniversityAccount }: UniversitySelec
       <div className='grid gap-4 sm:grid-cols-2'>
         <Button
           variant='outline'
-          className='h-24 flex flex-col items-center justify-center'
+          className='h-auto min-h-24 flex flex-col items-center justify-center whitespace-normal px-2 text-center'
           onClick={() => setHasUniversityAccount(true)}
         >
           <School className='h-6 w-6 mb-2' />
@@ -20,7 +20,7 @@ export const UniversitySelection = ({ setHasUniversityAccount }: UniversitySelec
         </Button>
         <Button
           variant='outline'
-          className='h-24 flex flex-col items-center justify-center'
+          className='h-auto min-h-24 flex flex-col items-center justify-center whitespace-normal px-2 text-center'
           onClick={() => setHasUniversityAccount(false)}
         >
           <UserPlus className='h-6 w-6 mb-2' />


### PR DESCRIPTION
## Summary

The "Add New Application" modal overflowed its bounds on smaller windows (search field, results table, and buttons spilled onto the backdrop) and was too narrow for the results table on desktop. This makes the modal responsive and sizes it appropriately per step.

## Details

- **Step-aware width.** The modal width is now conditional: the initial type-selection step stays compact, while the student-search (table) step and the application-form steps use `max-w-[900px]`. Dropping the `sm:` prefix is the key fix — it lets `tailwind-merge` remove the shared `DialogContent` base `max-w-lg`, which had silently pinned the modal at 512px regardless of the intended width.
- **No more overflow.** `DialogContent` gets `overflow-y-auto` and `[&>*]:min-w-0` so its grid children can shrink to fit instead of forcing the track wider than the modal and spilling onto the backdrop.
- **Search step.** The form stacks on small screens (`flex-col sm:flex-row`), the input can shrink (`min-w-0 flex-1`), and the Search button stays put (`shrink-0`). The results table sits in a native `overflow-auto` container so it scrolls inside the modal rather than overflowing.
- **Type selection.** The two option buttons wrap their labels (`whitespace-normal`, centered) instead of forcing the modal wider.

## Reason / Link to issue

Closes #1992. Closes #1938. Reproduction: Course Phase → Application → Add Application, then make the window smaller — the modal content overflowed. The modal was also effectively stuck at 512px, crowding the results table.

## How to Test

1. Open **Add Application** on the Application participants page and shrink the window — content stays within the modal (search form stacks, results table scrolls, type-selection cards wrap); nothing spills onto the backdrop.
2. On a normal desktop width, the search and application-form steps render at 900px with the full results table (incl. the Select action) visible; the initial type-selection step stays compact.

## Screenshots
Before:
<img width="1230" height="802" alt="image" src="https://github.com/user-attachments/assets/efd7b58e-102c-45a6-a20b-6a21ee19e983" />
<img width="800" height="680" alt="Screenshot 2026-07-23 at 15 04 43" src="https://github.com/user-attachments/assets/a92a357e-a992-4938-a7f2-a47366ec3af8" />

After: 
<img width="689" height="403" alt="Screenshot 2026-07-23 at 15 05 59" src="https://github.com/user-attachments/assets/75a73f32-6dbd-427d-9de4-5647583e4905" />

<img width="762" height="599" alt="Screenshot 2026-07-23 at 15 06 14" src="https://github.com/user-attachments/assets/385caf89-3359-46ab-8237-1d003b73f686" />
<img width="1180" height="589" alt="Screenshot 2026-07-23 at 15 06 04" src="https://github.com/user-attachments/assets/6458a979-1920-45c7-8f0a-23868ef133c2" />




## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
