### PR TITLE
`Development`: Ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ Thumbs.db
 .claude/worktrees/
 .gemini/
 .worktrees/
+CLAUDE.local.md
 
 # =============================================================================
 # Local Tooling (not shared)


### PR DESCRIPTION
## Summary

Adds `CLAUDE.local.md` to `.gitignore` so per-developer local Claude instructions are not committed.

## Details

Adds a single `CLAUDE.local.md` entry under the existing local-tooling ignores in `.gitignore`.

## Reason / Link to issue

`CLAUDE.local.md` holds machine- or developer-specific Claude context that shouldn't be shared, so it belongs in the ignore list alongside the other local tooling files.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
