### PR TITLE
`Assessment`: Fix feedback item writes trusting client-supplied identity fields

### DIFF
--- a/servers/assessment/database_dumps/feedbackItems.sql
+++ b/servers/assessment/database_dumps/feedbackItems.sql
@@ -49,6 +49,51 @@ CREATE TABLE public.course_participation (
     CONSTRAINT course_participation_pkey PRIMARY KEY (id)
 );
 
+CREATE TABLE public.assessment_schema (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name text NOT NULL,
+    description text,
+    CONSTRAINT assessment_schema_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE public.course_phase_config (
+    assessment_schema_id uuid NOT NULL,
+    course_phase_id uuid NOT NULL,
+    deadline timestamp with time zone DEFAULT NULL,
+    self_evaluation_enabled boolean NOT NULL DEFAULT false,
+    self_evaluation_schema uuid,
+    self_evaluation_deadline timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    peer_evaluation_enabled boolean NOT NULL DEFAULT false,
+    peer_evaluation_schema uuid,
+    peer_evaluation_deadline timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    start timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    self_evaluation_start timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    peer_evaluation_start timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    tutor_evaluation_enabled boolean NOT NULL DEFAULT false,
+    tutor_evaluation_start timestamp with time zone,
+    tutor_evaluation_deadline timestamp with time zone,
+    tutor_evaluation_schema uuid,
+    evaluation_results_visible boolean NOT NULL DEFAULT true,
+    grade_suggestion_visible boolean NOT NULL DEFAULT true,
+    action_items_visible boolean NOT NULL DEFAULT true,
+    results_released boolean NOT NULL DEFAULT false,
+    grading_sheet_visible boolean NOT NULL DEFAULT false,
+    CONSTRAINT course_phase_config_pkey PRIMARY KEY (course_phase_id),
+    CONSTRAINT course_phase_config_assessment_schema_id_fkey FOREIGN KEY (assessment_schema_id) REFERENCES public.assessment_schema(id) ON DELETE CASCADE
+);
+
+CREATE TABLE public.evaluation_completion (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    course_participation_id uuid NOT NULL,
+    course_phase_id uuid NOT NULL,
+    author_course_participation_id uuid NOT NULL,
+    completed_at timestamp with time zone NOT NULL,
+    completed boolean DEFAULT false NOT NULL,
+    type public.assessment_type NOT NULL DEFAULT 'self',
+    CONSTRAINT evaluation_completion_pkey PRIMARY KEY (id),
+    CONSTRAINT evaluation_completion_unique_constraint UNIQUE (course_participation_id, course_phase_id, author_course_participation_id)
+);
+
 -- Main feedback items table
 CREATE TABLE public.feedback_items (
     id uuid NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -71,6 +116,24 @@ INSERT INTO public.course_participation (id, course_id, user_email, role) VALUES
 ('ca42e447-60f9-4fe0-b297-2dae3f924fd7', '12345678-1234-1234-1234-123456789abc', 'student1@example.com', 'student'),
 ('da42e447-60f9-4fe0-b297-2dae3f924fd7', '12345678-1234-1234-1234-123456789abc', 'student2@example.com', 'student'),
 ('ea42e447-60f9-4fe0-b297-2dae3f924fd7', '12345678-1234-1234-1234-123456789abc', 'lecturer@example.com', 'lecturer');
+
+-- Insert test data for assessment schemas
+INSERT INTO public.assessment_schema (id, name, description) VALUES
+('550e8400-e29b-41d4-a716-446655440000', 'Test Assessment Schema', 'Test schema for unit tests');
+
+-- Insert test course phase configurations with all evaluation types open
+INSERT INTO public.course_phase_config (assessment_schema_id, course_phase_id, deadline, start,
+                                        self_evaluation_enabled, self_evaluation_start, self_evaluation_deadline,
+                                        peer_evaluation_enabled, peer_evaluation_start, peer_evaluation_deadline,
+                                        tutor_evaluation_enabled, tutor_evaluation_start, tutor_evaluation_deadline) VALUES
+('550e8400-e29b-41d4-a716-446655440000', '24461b6b-3c3a-4bc6-ba42-69eeb1514da9', '2099-12-31 23:59:59+00', '2024-01-01 00:00:00+00',
+ true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00',
+ true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00',
+ true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00'),
+('550e8400-e29b-41d4-a716-446655440000', '34561b6b-3c3a-4bc6-ba42-69eeb1514da9', '2099-12-31 23:59:59+00', '2024-01-01 00:00:00+00',
+ true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00',
+ true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00',
+ true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00');
 
 -- Insert test data for feedback items
 INSERT INTO public.feedback_items (id, feedback_type, feedback_text, course_participation_id, course_phase_id, author_course_participation_id) VALUES

--- a/servers/assessment/database_dumps/feedbackItems.sql
+++ b/servers/assessment/database_dumps/feedbackItems.sql
@@ -109,7 +109,8 @@ CREATE TABLE public.feedback_items (
 -- Insert test data for course phases
 INSERT INTO public.course_phase (id, name, course_id, start_date, end_date) VALUES
 ('24461b6b-3c3a-4bc6-ba42-69eeb1514da9', 'Test Phase 1', '12345678-1234-1234-1234-123456789abc', '2024-01-01', '2024-06-30'),
-('34561b6b-3c3a-4bc6-ba42-69eeb1514da9', 'Test Phase 2', '12345678-1234-1234-1234-123456789abc', '2024-07-01', '2024-12-31');
+('34561b6b-3c3a-4bc6-ba42-69eeb1514da9', 'Test Phase 2', '12345678-1234-1234-1234-123456789abc', '2024-07-01', '2024-12-31'),
+('44561b6b-3c3a-4bc6-ba42-69eeb1514da9', 'Test Phase 3 (not started)', '12345678-1234-1234-1234-123456789abc', '2024-07-01', '2024-12-31');
 
 -- Insert test data for course participations
 INSERT INTO public.course_participation (id, course_id, user_email, role) VALUES
@@ -133,7 +134,16 @@ INSERT INTO public.course_phase_config (assessment_schema_id, course_phase_id, d
 ('550e8400-e29b-41d4-a716-446655440000', '34561b6b-3c3a-4bc6-ba42-69eeb1514da9', '2099-12-31 23:59:59+00', '2024-01-01 00:00:00+00',
  true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00',
  true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00',
- true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00');
+ true, '2024-01-01 00:00:00+00', '2099-12-31 23:59:59+00'),
+-- Phase 3 has self evaluation enabled but not yet started
+('550e8400-e29b-41d4-a716-446655440000', '44561b6b-3c3a-4bc6-ba42-69eeb1514da9', '2099-12-31 23:59:59+00', '2099-01-01 00:00:00+00',
+ true, '2099-01-01 00:00:00+00', '2099-12-31 23:59:59+00',
+ true, '2099-01-01 00:00:00+00', '2099-12-31 23:59:59+00',
+ true, '2099-01-01 00:00:00+00', '2099-12-31 23:59:59+00');
+
+-- A completed self evaluation locks further writes for that author in phase 2
+INSERT INTO public.evaluation_completion (course_participation_id, course_phase_id, author_course_participation_id, completed_at, completed, type) VALUES
+('ca42e447-60f9-4fe0-b297-2dae3f924fd7', '34561b6b-3c3a-4bc6-ba42-69eeb1514da9', 'ca42e447-60f9-4fe0-b297-2dae3f924fd7', '2024-02-01 00:00:00+00', true, 'self');
 
 -- Insert test data for feedback items
 INSERT INTO public.feedback_items (id, feedback_type, feedback_text, course_participation_id, course_phase_id, author_course_participation_id) VALUES

--- a/servers/assessment/db/query/feedback_item.sql
+++ b/servers/assessment/db/query/feedback_item.sql
@@ -13,15 +13,13 @@ INSERT INTO feedback_items (id,
                             type)
 VALUES ($1, $2, $3, $4, $5, $6, $7);
 
--- name: UpdateFeedbackItem :exec
+-- name: UpdateFeedbackItem :execrows
 UPDATE feedback_items
-SET feedback_type                  = $2,
-    feedback_text                  = $3,
-    course_participation_id        = $4,
-    course_phase_id                = $5,
-    author_course_participation_id = $6,
-    type                           = $7
-WHERE id = $1;
+SET feedback_type = $4,
+    feedback_text = $5
+WHERE id = $1
+  AND course_phase_id = $2
+  AND author_course_participation_id = $3;
 
 -- name: DeleteFeedbackItem :exec
 DELETE

--- a/servers/assessment/db/sqlc/feedback_item.sql.go
+++ b/servers/assessment/db/sqlc/feedback_item.sql.go
@@ -242,36 +242,33 @@ func (q *Queries) ListFeedbackItemsForTutorInPhase(ctx context.Context, arg List
 	return items, nil
 }
 
-const updateFeedbackItem = `-- name: UpdateFeedbackItem :exec
+const updateFeedbackItem = `-- name: UpdateFeedbackItem :execrows
 UPDATE feedback_items
-SET feedback_type                  = $2,
-    feedback_text                  = $3,
-    course_participation_id        = $4,
-    course_phase_id                = $5,
-    author_course_participation_id = $6,
-    type                           = $7
+SET feedback_type = $4,
+    feedback_text = $5
 WHERE id = $1
+  AND course_phase_id = $2
+  AND author_course_participation_id = $3
 `
 
 type UpdateFeedbackItemParams struct {
-	ID                          uuid.UUID      `json:"id"`
-	FeedbackType                FeedbackType   `json:"feedback_type"`
-	FeedbackText                string         `json:"feedback_text"`
-	CourseParticipationID       uuid.UUID      `json:"course_participation_id"`
-	CoursePhaseID               uuid.UUID      `json:"course_phase_id"`
-	AuthorCourseParticipationID uuid.UUID      `json:"author_course_participation_id"`
-	Type                        AssessmentType `json:"type"`
+	ID                          uuid.UUID    `json:"id"`
+	CoursePhaseID               uuid.UUID    `json:"course_phase_id"`
+	AuthorCourseParticipationID uuid.UUID    `json:"author_course_participation_id"`
+	FeedbackType                FeedbackType `json:"feedback_type"`
+	FeedbackText                string       `json:"feedback_text"`
 }
 
-func (q *Queries) UpdateFeedbackItem(ctx context.Context, arg UpdateFeedbackItemParams) error {
-	_, err := q.db.Exec(ctx, updateFeedbackItem,
+func (q *Queries) UpdateFeedbackItem(ctx context.Context, arg UpdateFeedbackItemParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateFeedbackItem,
 		arg.ID,
-		arg.FeedbackType,
-		arg.FeedbackText,
-		arg.CourseParticipationID,
 		arg.CoursePhaseID,
 		arg.AuthorCourseParticipationID,
-		arg.Type,
+		arg.FeedbackType,
+		arg.FeedbackText,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/servers/assessment/docs/docs.go
+++ b/servers/assessment/docs/docs.go
@@ -1785,6 +1785,15 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -2280,6 +2289,15 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -2524,6 +2542,15 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2863,6 +2890,15 @@ const docTemplate = `{
                     },
                     "403": {
                         "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/servers/assessment/docs/docs.go
+++ b/servers/assessment/docs/docs.go
@@ -2522,6 +2522,15 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -5486,24 +5495,10 @@ const docTemplate = `{
         "feedbackItemDTO.UpdateFeedbackItemRequest": {
             "type": "object",
             "required": [
-                "authorCourseParticipationID",
-                "courseParticipationID",
-                "coursePhaseID",
                 "feedbackText",
-                "feedbackType",
-                "id",
-                "type"
+                "feedbackType"
             ],
             "properties": {
-                "authorCourseParticipationID": {
-                    "type": "string"
-                },
-                "courseParticipationID": {
-                    "type": "string"
-                },
-                "coursePhaseID": {
-                    "type": "string"
-                },
                 "feedbackText": {
                     "type": "string"
                 },
@@ -5515,22 +5510,6 @@ const docTemplate = `{
                     "allOf": [
                         {
                             "$ref": "#/definitions/db.FeedbackType"
-                        }
-                    ]
-                },
-                "id": {
-                    "type": "string"
-                },
-                "type": {
-                    "enum": [
-                        "self",
-                        "peer",
-                        "tutor",
-                        "assessment"
-                    ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/assessmentType.AssessmentType"
                         }
                     ]
                 }

--- a/servers/assessment/docs/swagger.json
+++ b/servers/assessment/docs/swagger.json
@@ -1779,6 +1779,15 @@
                             }
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -2274,6 +2283,15 @@
                             }
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -2518,6 +2536,15 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -2857,6 +2884,15 @@
                     },
                     "403": {
                         "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/servers/assessment/docs/swagger.json
+++ b/servers/assessment/docs/swagger.json
@@ -2516,6 +2516,15 @@
                             }
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -5480,24 +5489,10 @@
         "feedbackItemDTO.UpdateFeedbackItemRequest": {
             "type": "object",
             "required": [
-                "authorCourseParticipationID",
-                "courseParticipationID",
-                "coursePhaseID",
                 "feedbackText",
-                "feedbackType",
-                "id",
-                "type"
+                "feedbackType"
             ],
             "properties": {
-                "authorCourseParticipationID": {
-                    "type": "string"
-                },
-                "courseParticipationID": {
-                    "type": "string"
-                },
-                "coursePhaseID": {
-                    "type": "string"
-                },
                 "feedbackText": {
                     "type": "string"
                 },
@@ -5509,22 +5504,6 @@
                     "allOf": [
                         {
                             "$ref": "#/definitions/db.FeedbackType"
-                        }
-                    ]
-                },
-                "id": {
-                    "type": "string"
-                },
-                "type": {
-                    "enum": [
-                        "self",
-                        "peer",
-                        "tutor",
-                        "assessment"
-                    ],
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/assessmentType.AssessmentType"
                         }
                     ]
                 }

--- a/servers/assessment/docs/swagger.yaml
+++ b/servers/assessment/docs/swagger.yaml
@@ -696,12 +696,6 @@ definitions:
     type: object
   feedbackItemDTO.UpdateFeedbackItemRequest:
     properties:
-      authorCourseParticipationID:
-        type: string
-      courseParticipationID:
-        type: string
-      coursePhaseID:
-        type: string
       feedbackText:
         type: string
       feedbackType:
@@ -710,24 +704,9 @@ definitions:
         enum:
         - positive
         - negative
-      id:
-        type: string
-      type:
-        allOf:
-        - $ref: '#/definitions/assessmentType.AssessmentType'
-        enum:
-        - self
-        - peer
-        - tutor
-        - assessment
     required:
-    - authorCourseParticipationID
-    - courseParticipationID
-    - coursePhaseID
     - feedbackText
     - feedbackType
-    - id
-    - type
     type: object
   pgtype.Float8:
     properties:
@@ -2566,6 +2545,12 @@ paths:
             type: object
         "403":
           description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
           schema:
             additionalProperties:
               type: string

--- a/servers/assessment/docs/swagger.yaml
+++ b/servers/assessment/docs/swagger.yaml
@@ -2090,6 +2090,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Internal Server Error
           schema:
@@ -2126,6 +2132,12 @@ paths:
             type: object
         "403":
           description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
           schema:
             additionalProperties:
               type: string
@@ -2458,6 +2470,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Internal Server Error
           schema:
@@ -2551,6 +2569,12 @@ paths:
             type: object
         "404":
           description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
           schema:
             additionalProperties:
               type: string

--- a/servers/assessment/evaluations/evaluationCompletion/router.go
+++ b/servers/assessment/evaluations/evaluationCompletion/router.go
@@ -96,6 +96,10 @@ func createOrUpdateMyEvaluationCompletion(c *gin.Context) {
 			handleError(c, http.StatusForbidden, err)
 			return
 		}
+		if errors.Is(err, ErrEvaluationAlreadyCompleted) {
+			handleError(c, http.StatusConflict, err)
+			return
+		}
 		handleError(c, http.StatusInternalServerError, err)
 		return
 	}
@@ -140,6 +144,10 @@ func markMyEvaluationAsCompleted(c *gin.Context) {
 	if err != nil {
 		if errors.Is(err, coursePhaseConfig.ErrNotStarted) {
 			handleError(c, http.StatusForbidden, err)
+			return
+		}
+		if errors.Is(err, ErrEvaluationAlreadyCompleted) {
+			handleError(c, http.StatusConflict, err)
 			return
 		}
 		handleError(c, http.StatusInternalServerError, err)

--- a/servers/assessment/evaluations/evaluationCompletion/service.go
+++ b/servers/assessment/evaluations/evaluationCompletion/service.go
@@ -26,6 +26,7 @@ var EvaluationCompletionServiceSingleton *EvaluationCompletionService
 
 var ErrInvalidEvaluationType = errors.New("invalid evaluation type")
 var ErrSelfEvaluationTargetMismatch = errors.New("self evaluation must target its author")
+var ErrEvaluationAlreadyCompleted = errors.New("evaluation completion already exists and is marked as completed")
 
 func CheckEvaluationIsEditable(ctx context.Context, qtx *db.Queries, courseParticipationID, coursePhaseID, authorCourseParticipationID uuid.UUID, evaluationType assessmentType.AssessmentType) error {
 	if evaluationType == assessmentType.Self && courseParticipationID != authorCourseParticipationID {
@@ -73,8 +74,7 @@ func CheckEvaluationIsEditable(ctx context.Context, qtx *db.Queries, courseParti
 		}
 
 		if completion.Completed {
-			log.Error("evaluation completion already exists and is marked as completed")
-			return errors.New("evaluation completion already exists and is marked as completed")
+			return ErrEvaluationAlreadyCompleted
 		}
 	}
 	return nil

--- a/servers/assessment/evaluations/feedbackItem/feedbackItemDTO/updateFeedbackItemRequest.go
+++ b/servers/assessment/evaluations/feedbackItem/feedbackItemDTO/updateFeedbackItemRequest.go
@@ -1,17 +1,10 @@
 package feedbackItemDTO
 
 import (
-	"github.com/google/uuid"
-	"github.com/prompt-edu/prompt/servers/assessment/assessmentType"
 	db "github.com/prompt-edu/prompt/servers/assessment/db/sqlc"
 )
 
 type UpdateFeedbackItemRequest struct {
-	ID                          uuid.UUID                     `json:"id" binding:"required,uuid"`
-	FeedbackType                db.FeedbackType               `json:"feedbackType" binding:"required,oneof='positive' 'negative'"`
-	FeedbackText                string                        `json:"feedbackText" binding:"required"`
-	CourseParticipationID       uuid.UUID                     `json:"courseParticipationID" binding:"required,uuid"`
-	CoursePhaseID               uuid.UUID                     `json:"coursePhaseID" binding:"required,uuid"`
-	AuthorCourseParticipationID uuid.UUID                     `json:"authorCourseParticipationID" binding:"required,uuid"`
-	Type                        assessmentType.AssessmentType `json:"type" binding:"required,oneof='self' 'peer' 'tutor' 'assessment'"`
+	FeedbackType db.FeedbackType `json:"feedbackType" binding:"required,oneof='positive' 'negative'"`
+	FeedbackText string          `json:"feedbackText" binding:"required"`
 }

--- a/servers/assessment/evaluations/feedbackItem/router.go
+++ b/servers/assessment/evaluations/feedbackItem/router.go
@@ -1,11 +1,13 @@
 package feedbackItem
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
+	"github.com/prompt-edu/prompt/servers/assessment/evaluations/evaluationCompletion"
 	"github.com/prompt-edu/prompt/servers/assessment/evaluations/feedbackItem/feedbackItemDTO"
 	"github.com/prompt-edu/prompt/servers/assessment/utils"
 	log "github.com/sirupsen/logrus"
@@ -191,7 +193,7 @@ func createFeedbackItem(c *gin.Context) {
 
 	err = CreateFeedbackItem(c, req)
 	if err != nil {
-		handleError(c, http.StatusInternalServerError, err)
+		handleError(c, feedbackItemErrorStatus(err), err)
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"message": "Feedback item created successfully"})
@@ -209,6 +211,7 @@ func createFeedbackItem(c *gin.Context) {
 // @Success 201 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 403 {object} map[string]string
+// @Failure 404 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /course_phase/{coursePhaseID}/evaluation/feedback-items/{feedbackItemID} [put]
 func updateFeedbackItem(c *gin.Context) {
@@ -219,23 +222,28 @@ func updateFeedbackItem(c *gin.Context) {
 		return
 	}
 
+	feedbackItemID, err := uuid.Parse(c.Param("feedbackItemID"))
+	if err != nil {
+		log.Error("Error parsing feedbackItemID: ", err)
+		handleError(c, http.StatusBadRequest, err)
+		return
+	}
+
 	var req feedbackItemDTO.UpdateFeedbackItemRequest
 	if err := c.BindJSON(&req); err != nil {
 		handleError(c, http.StatusBadRequest, err)
 		return
 	}
 
-	statusCode, err := utils.ValidateStudentOwnership(c, req.AuthorCourseParticipationID)
+	courseParticipationID, err := utils.GetUserCourseParticipationID(c)
 	if err != nil {
-		handleError(c, statusCode, err)
+		handleError(c, utils.GetUserCourseParticipationIDErrorStatus(err), err)
 		return
 	}
 
-	req.CoursePhaseID = coursePhaseID
-
-	err = UpdateFeedbackItem(c, req)
+	err = UpdateFeedbackItem(c, feedbackItemID, coursePhaseID, courseParticipationID, req)
 	if err != nil {
-		handleError(c, http.StatusInternalServerError, err)
+		handleError(c, feedbackItemErrorStatus(err), err)
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"message": "Feedback item updated successfully"})
@@ -276,6 +284,20 @@ func deleteFeedbackItem(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusOK)
+}
+
+func feedbackItemErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, ErrFeedbackItemNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, ErrNotFeedbackItemAuthor):
+		return http.StatusForbidden
+	case errors.Is(err, evaluationCompletion.ErrInvalidEvaluationType),
+		errors.Is(err, evaluationCompletion.ErrSelfEvaluationTargetMismatch):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
 }
 
 func handleError(c *gin.Context, statusCode int, err error) {

--- a/servers/assessment/evaluations/feedbackItem/router.go
+++ b/servers/assessment/evaluations/feedbackItem/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
+	"github.com/prompt-edu/prompt/servers/assessment/coursePhaseConfig"
 	"github.com/prompt-edu/prompt/servers/assessment/evaluations/evaluationCompletion"
 	"github.com/prompt-edu/prompt/servers/assessment/evaluations/feedbackItem/feedbackItemDTO"
 	"github.com/prompt-edu/prompt/servers/assessment/utils"
@@ -161,6 +162,7 @@ func getMyFeedbackItems(c *gin.Context) {
 // @Success 201 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 403 {object} map[string]string
+// @Failure 409 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /course_phase/{coursePhaseID}/evaluation/feedback-items [post]
 func createFeedbackItem(c *gin.Context) {
@@ -212,6 +214,7 @@ func createFeedbackItem(c *gin.Context) {
 // @Failure 400 {object} map[string]string
 // @Failure 403 {object} map[string]string
 // @Failure 404 {object} map[string]string
+// @Failure 409 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /course_phase/{coursePhaseID}/evaluation/feedback-items/{feedbackItemID} [put]
 func updateFeedbackItem(c *gin.Context) {
@@ -290,8 +293,10 @@ func feedbackItemErrorStatus(err error) int {
 	switch {
 	case errors.Is(err, ErrFeedbackItemNotFound):
 		return http.StatusNotFound
-	case errors.Is(err, ErrNotFeedbackItemAuthor):
+	case errors.Is(err, ErrNotFeedbackItemAuthor), errors.Is(err, coursePhaseConfig.ErrNotStarted):
 		return http.StatusForbidden
+	case errors.Is(err, evaluationCompletion.ErrEvaluationAlreadyCompleted):
+		return http.StatusConflict
 	case errors.Is(err, evaluationCompletion.ErrInvalidEvaluationType),
 		errors.Is(err, evaluationCompletion.ErrSelfEvaluationTargetMismatch):
 		return http.StatusBadRequest

--- a/servers/assessment/evaluations/feedbackItem/router_test.go
+++ b/servers/assessment/evaluations/feedbackItem/router_test.go
@@ -140,6 +140,48 @@ func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemSelfTargetMismat
 	assert.Equal(suite.T(), http.StatusBadRequest, resp.Code)
 }
 
+func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemBeforeWindowOpens() {
+	notStartedPhaseID := uuid.MustParse("44561b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	authorID := uuid.MustParse("ca42e447-60f9-4fe0-b297-2dae3f924fd7")
+
+	payload := feedbackItemDTO.CreateFeedbackItemRequest{
+		FeedbackType:                db.FeedbackTypePositive,
+		FeedbackText:                "Submitted before the window opens",
+		CourseParticipationID:       authorID,
+		CoursePhaseID:               notStartedPhaseID,
+		AuthorCourseParticipationID: authorID,
+		Type:                        assessmentType.Self,
+	}
+	body, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/api/course_phase/"+notStartedPhaseID.String()+"/evaluation/feedback-items", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+	assert.Equal(suite.T(), http.StatusForbidden, resp.Code)
+}
+
+func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemAfterCompletion() {
+	completedPhaseID := uuid.MustParse("34561b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	authorID := uuid.MustParse("ca42e447-60f9-4fe0-b297-2dae3f924fd7")
+
+	payload := feedbackItemDTO.CreateFeedbackItemRequest{
+		FeedbackType:                db.FeedbackTypePositive,
+		FeedbackText:                "Added after marking the evaluation complete",
+		CourseParticipationID:       authorID,
+		CoursePhaseID:               completedPhaseID,
+		AuthorCourseParticipationID: authorID,
+		Type:                        assessmentType.Self,
+	}
+	body, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/api/course_phase/"+completedPhaseID.String()+"/evaluation/feedback-items", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+	assert.Equal(suite.T(), http.StatusConflict, resp.Code)
+}
+
 func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemRejectsAssessmentType() {
 	phaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
 	authorID := uuid.MustParse("ca42e447-60f9-4fe0-b297-2dae3f924fd7")

--- a/servers/assessment/evaluations/feedbackItem/router_test.go
+++ b/servers/assessment/evaluations/feedbackItem/router_test.go
@@ -99,13 +99,12 @@ func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemInvalidJSON() {
 
 func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemValid() {
 	phaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
-	studentID := uuid.MustParse("da42e447-60f9-4fe0-b297-2dae3f924fd7") // target student
-	authorID := uuid.MustParse("ca42e447-60f9-4fe0-b297-2dae3f924fd7")  // current student
+	authorID := uuid.MustParse("ca42e447-60f9-4fe0-b297-2dae3f924fd7") // current student
 
 	payload := feedbackItemDTO.CreateFeedbackItemRequest{
 		FeedbackType:                db.FeedbackTypePositive,
 		FeedbackText:                "Test positive feedback",
-		CourseParticipationID:       studentID,
+		CourseParticipationID:       authorID, // self feedback: subject is the author
 		CoursePhaseID:               phaseID,
 		AuthorCourseParticipationID: authorID,
 		Type:                        assessmentType.Self,
@@ -117,6 +116,49 @@ func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemValid() {
 
 	suite.router.ServeHTTP(resp, req)
 	assert.Equal(suite.T(), http.StatusCreated, resp.Code)
+}
+
+func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemSelfTargetMismatch() {
+	phaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	victimID := uuid.MustParse("da42e447-60f9-4fe0-b297-2dae3f924fd7") // peer, not the author
+	authorID := uuid.MustParse("ca42e447-60f9-4fe0-b297-2dae3f924fd7") // current student
+
+	payload := feedbackItemDTO.CreateFeedbackItemRequest{
+		FeedbackType:                db.FeedbackTypeNegative,
+		FeedbackText:                "Injected into a peer's self feedback",
+		CourseParticipationID:       victimID,
+		CoursePhaseID:               phaseID,
+		AuthorCourseParticipationID: authorID,
+		Type:                        assessmentType.Self,
+	}
+	body, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/api/course_phase/"+phaseID.String()+"/evaluation/feedback-items", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+	assert.Equal(suite.T(), http.StatusBadRequest, resp.Code)
+}
+
+func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemRejectsAssessmentType() {
+	phaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	authorID := uuid.MustParse("ca42e447-60f9-4fe0-b297-2dae3f924fd7")
+
+	payload := feedbackItemDTO.CreateFeedbackItemRequest{
+		FeedbackType:                db.FeedbackTypePositive,
+		FeedbackText:                "Forged tutor-side assessment feedback",
+		CourseParticipationID:       authorID,
+		CoursePhaseID:               phaseID,
+		AuthorCourseParticipationID: authorID,
+		Type:                        assessmentType.Assessment,
+	}
+	body, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/api/course_phase/"+phaseID.String()+"/evaluation/feedback-items", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+	assert.Equal(suite.T(), http.StatusBadRequest, resp.Code)
 }
 
 func (suite *FeedbackItemRouterTestSuite) TestCreateFeedbackItemUnauthorizedAuthor() {
@@ -152,6 +194,85 @@ func (suite *FeedbackItemRouterTestSuite) TestGetMyFeedbackItems() {
 	var feedbackItems []feedbackItemDTO.FeedbackItem
 	err := json.Unmarshal(resp.Body.Bytes(), &feedbackItems)
 	assert.NoError(suite.T(), err)
+}
+
+// seedOwnFeedbackItem inserts a self feedback item authored by the current test student
+// so update tests do not depend on rows other tests mutate.
+func (suite *FeedbackItemRouterTestSuite) seedOwnFeedbackItem(phaseID uuid.UUID) uuid.UUID {
+	currentStudentID := uuid.MustParse("ca42e447-60f9-4fe0-b297-2dae3f924fd7")
+	feedbackItemID := uuid.New()
+
+	err := suite.service.queries.CreateFeedbackItem(suite.suiteCtx, db.CreateFeedbackItemParams{
+		ID:                          feedbackItemID,
+		FeedbackType:                db.FeedbackTypeNegative,
+		FeedbackText:                "Original feedback text",
+		CourseParticipationID:       currentStudentID,
+		CoursePhaseID:               phaseID,
+		AuthorCourseParticipationID: currentStudentID,
+		Type:                        db.AssessmentTypeSelf,
+	})
+	assert.NoError(suite.T(), err)
+	return feedbackItemID
+}
+
+func (suite *FeedbackItemRouterTestSuite) updateRequest(phaseID, feedbackItemID uuid.UUID) *httptest.ResponseRecorder {
+	payload := feedbackItemDTO.UpdateFeedbackItemRequest{
+		FeedbackType: db.FeedbackTypePositive,
+		FeedbackText: "Rewritten feedback text",
+	}
+	body, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("PUT", "/api/course_phase/"+phaseID.String()+"/evaluation/feedback-items/"+feedbackItemID.String(), bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	suite.router.ServeHTTP(resp, req)
+	return resp
+}
+
+func (suite *FeedbackItemRouterTestSuite) TestUpdateFeedbackItemValid() {
+	phaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	feedbackItemID := suite.seedOwnFeedbackItem(phaseID)
+
+	resp := suite.updateRequest(phaseID, feedbackItemID)
+	assert.Equal(suite.T(), http.StatusCreated, resp.Code)
+
+	updated, err := GetFeedbackItem(suite.suiteCtx, feedbackItemID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Rewritten feedback text", updated.FeedbackText)
+	assert.Equal(suite.T(), db.FeedbackTypePositive, updated.FeedbackType)
+}
+
+func (suite *FeedbackItemRouterTestSuite) TestUpdateFeedbackItemNotAuthor() {
+	phaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	feedbackItemID := uuid.MustParse("22222222-2222-2222-2222-222222222222") // authored by ea42e447 (lecturer)
+
+	resp := suite.updateRequest(phaseID, feedbackItemID)
+	assert.Equal(suite.T(), http.StatusForbidden, resp.Code)
+
+	unchanged, err := GetFeedbackItem(suite.suiteCtx, feedbackItemID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Need to improve time management", unchanged.FeedbackText)
+	assert.Equal(suite.T(), uuid.MustParse("ea42e447-60f9-4fe0-b297-2dae3f924fd7"), unchanged.AuthorCourseParticipationID)
+}
+
+func (suite *FeedbackItemRouterTestSuite) TestUpdateFeedbackItemWrongPhase() {
+	phaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	otherPhaseID := uuid.MustParse("34561b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	feedbackItemID := suite.seedOwnFeedbackItem(phaseID)
+
+	resp := suite.updateRequest(otherPhaseID, feedbackItemID)
+	assert.Equal(suite.T(), http.StatusNotFound, resp.Code)
+
+	unchanged, err := GetFeedbackItem(suite.suiteCtx, feedbackItemID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Original feedback text", unchanged.FeedbackText)
+}
+
+func (suite *FeedbackItemRouterTestSuite) TestUpdateFeedbackItemUnknownID() {
+	phaseID := uuid.MustParse("24461b6b-3c3a-4bc6-ba42-69eeb1514da9")
+
+	resp := suite.updateRequest(phaseID, uuid.New())
+	assert.Equal(suite.T(), http.StatusNotFound, resp.Code)
 }
 
 func (suite *FeedbackItemRouterTestSuite) TestDeleteFeedbackItemValid() {

--- a/servers/assessment/evaluations/feedbackItem/service.go
+++ b/servers/assessment/evaluations/feedbackItem/service.go
@@ -3,14 +3,21 @@ package feedbackItem
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	promptSDK "github.com/prompt-edu/prompt-sdk"
 	"github.com/prompt-edu/prompt/servers/assessment/assessmentType"
 	db "github.com/prompt-edu/prompt/servers/assessment/db/sqlc"
+	"github.com/prompt-edu/prompt/servers/assessment/evaluations/evaluationCompletion"
 	"github.com/prompt-edu/prompt/servers/assessment/evaluations/feedbackItem/feedbackItemDTO"
 	log "github.com/sirupsen/logrus"
 )
+
+var ErrFeedbackItemNotFound = errors.New("feedback item not found")
+var ErrNotFeedbackItemAuthor = errors.New("you are not the author of this feedback item")
 
 type FeedbackItemService struct {
 	queries db.Queries
@@ -74,7 +81,20 @@ func ListFeedbackItemsByAuthorInPhase(ctx context.Context, authorCourseParticipa
 }
 
 func CreateFeedbackItem(ctx context.Context, req feedbackItemDTO.CreateFeedbackItemRequest) error {
-	err := FeedbackItemServiceSingleton.queries.CreateFeedbackItem(ctx, db.CreateFeedbackItemParams{
+	tx, err := FeedbackItemServiceSingleton.conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer promptSDK.DeferDBRollback(tx, ctx)
+
+	qtx := FeedbackItemServiceSingleton.queries.WithTx(tx)
+
+	err = evaluationCompletion.CheckEvaluationIsEditable(ctx, qtx, req.CourseParticipationID, req.CoursePhaseID, req.AuthorCourseParticipationID, req.Type)
+	if err != nil {
+		return err
+	}
+
+	err = qtx.CreateFeedbackItem(ctx, db.CreateFeedbackItemParams{
 		ID:                          uuid.New(),
 		FeedbackType:                req.FeedbackType,
 		FeedbackText:                req.FeedbackText,
@@ -87,23 +107,65 @@ func CreateFeedbackItem(ctx context.Context, req feedbackItemDTO.CreateFeedbackI
 		log.Error("could not create feedback item: ", err)
 		return errors.New("could not create feedback item")
 	}
+
+	if err := tx.Commit(ctx); err != nil {
+		log.Error(err)
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
 	return nil
 }
 
-func UpdateFeedbackItem(ctx context.Context, req feedbackItemDTO.UpdateFeedbackItemRequest) error {
-	err := FeedbackItemServiceSingleton.queries.UpdateFeedbackItem(ctx, db.UpdateFeedbackItemParams{
-		ID:                          req.ID,
+func UpdateFeedbackItem(ctx context.Context, feedbackItemID, coursePhaseID, authorCourseParticipationID uuid.UUID, req feedbackItemDTO.UpdateFeedbackItemRequest) error {
+	tx, err := FeedbackItemServiceSingleton.conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer promptSDK.DeferDBRollback(tx, ctx)
+
+	qtx := FeedbackItemServiceSingleton.queries.WithTx(tx)
+
+	existing, err := qtx.GetFeedbackItem(ctx, feedbackItemID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrFeedbackItemNotFound
+		}
+		log.Error("could not get feedback item: ", err)
+		return errors.New("could not get feedback item")
+	}
+
+	if existing.CoursePhaseID != coursePhaseID {
+		return ErrFeedbackItemNotFound
+	}
+	if existing.AuthorCourseParticipationID != authorCourseParticipationID {
+		return ErrNotFeedbackItemAuthor
+	}
+
+	err = evaluationCompletion.CheckEvaluationIsEditable(ctx, qtx, existing.CourseParticipationID, existing.CoursePhaseID, existing.AuthorCourseParticipationID, assessmentType.MapDBAssessmentTypeToDTO(existing.Type))
+	if err != nil {
+		return err
+	}
+
+	rows, err := qtx.UpdateFeedbackItem(ctx, db.UpdateFeedbackItemParams{
+		ID:                          feedbackItemID,
+		CoursePhaseID:               coursePhaseID,
+		AuthorCourseParticipationID: authorCourseParticipationID,
 		FeedbackType:                req.FeedbackType,
 		FeedbackText:                req.FeedbackText,
-		CourseParticipationID:       req.CourseParticipationID,
-		CoursePhaseID:               req.CoursePhaseID,
-		AuthorCourseParticipationID: req.AuthorCourseParticipationID,
-		Type:                        assessmentType.MapDTOtoDBAssessmentType(req.Type),
 	})
 	if err != nil {
 		log.Error("could not update feedback item: ", err)
 		return errors.New("could not update feedback item")
 	}
+	if rows == 0 {
+		return ErrFeedbackItemNotFound
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		log.Error(err)
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
 	return nil
 }
 

--- a/servers/assessment/evaluations/feedbackItem/service_test.go
+++ b/servers/assessment/evaluations/feedbackItem/service_test.go
@@ -12,6 +12,7 @@ import (
 	sdkTestUtils "github.com/prompt-edu/prompt-sdk/testutils"
 	"github.com/prompt-edu/prompt/servers/assessment/assessmentType"
 	db "github.com/prompt-edu/prompt/servers/assessment/db/sqlc"
+	"github.com/prompt-edu/prompt/servers/assessment/evaluations/evaluationCompletion"
 	"github.com/prompt-edu/prompt/servers/assessment/evaluations/feedbackItem/feedbackItemDTO"
 )
 
@@ -52,11 +53,29 @@ func (suite *FeedbackItemServiceTestSuite) TearDownSuite() {
 	}
 }
 
+// seedFeedbackItem inserts a self feedback item authored by the given participation
+// so tests that mutate rows do not depend on each other's ordering.
+func (suite *FeedbackItemServiceTestSuite) seedFeedbackItem(authorID uuid.UUID) uuid.UUID {
+	feedbackItemID := uuid.New()
+
+	err := suite.feedbackItemService.queries.CreateFeedbackItem(suite.suiteCtx, db.CreateFeedbackItemParams{
+		ID:                          feedbackItemID,
+		FeedbackType:                db.FeedbackTypePositive,
+		FeedbackText:                "Original feedback text",
+		CourseParticipationID:       authorID,
+		CoursePhaseID:               suite.testCoursePhaseID,
+		AuthorCourseParticipationID: authorID,
+		Type:                        db.AssessmentTypeSelf,
+	})
+	assert.NoError(suite.T(), err)
+	return feedbackItemID
+}
+
 func (suite *FeedbackItemServiceTestSuite) TestCreateFeedbackItem() {
 	req := feedbackItemDTO.CreateFeedbackItemRequest{
 		FeedbackType:                db.FeedbackTypePositive,
 		FeedbackText:                "Great work on this task!",
-		CourseParticipationID:       suite.testCourseParticipationID,
+		CourseParticipationID:       suite.testAuthorID, // self feedback: subject is the author
 		CoursePhaseID:               suite.testCoursePhaseID,
 		AuthorCourseParticipationID: suite.testAuthorID,
 		Type:                        assessmentType.Self,
@@ -66,20 +85,62 @@ func (suite *FeedbackItemServiceTestSuite) TestCreateFeedbackItem() {
 	assert.NoError(suite.T(), err)
 }
 
-func (suite *FeedbackItemServiceTestSuite) TestUpdateFeedbackItem() {
-	// Use the second feedback item ID to avoid interfering with other tests
-	updateFeedbackItemID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
-	req := feedbackItemDTO.UpdateFeedbackItemRequest{
-		ID:                          updateFeedbackItemID,
-		FeedbackType:                db.FeedbackTypePositive, // Change from negative to positive
-		FeedbackText:                "Updated feedback text",
-		CourseParticipationID:       suite.testCourseParticipationID,
+func (suite *FeedbackItemServiceTestSuite) TestCreateFeedbackItemRejectsForeignSelfTarget() {
+	req := feedbackItemDTO.CreateFeedbackItemRequest{
+		FeedbackType:                db.FeedbackTypePositive,
+		FeedbackText:                "Injected into a peer's self feedback",
+		CourseParticipationID:       suite.testCourseParticipationID, // not the author
 		CoursePhaseID:               suite.testCoursePhaseID,
 		AuthorCourseParticipationID: suite.testAuthorID,
+		Type:                        assessmentType.Self,
 	}
 
-	err := UpdateFeedbackItem(suite.suiteCtx, req)
+	err := CreateFeedbackItem(suite.suiteCtx, req)
+	assert.ErrorIs(suite.T(), err, evaluationCompletion.ErrSelfEvaluationTargetMismatch)
+}
+
+func (suite *FeedbackItemServiceTestSuite) TestUpdateFeedbackItem() {
+	updateFeedbackItemID := suite.seedFeedbackItem(suite.testAuthorID)
+	req := feedbackItemDTO.UpdateFeedbackItemRequest{
+		FeedbackType: db.FeedbackTypeNegative, // Change from positive to negative
+		FeedbackText: "Updated feedback text",
+	}
+
+	err := UpdateFeedbackItem(suite.suiteCtx, updateFeedbackItemID, suite.testCoursePhaseID, suite.testAuthorID, req)
 	assert.NoError(suite.T(), err)
+
+	updated, err := GetFeedbackItem(suite.suiteCtx, updateFeedbackItemID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Updated feedback text", updated.FeedbackText)
+	assert.Equal(suite.T(), db.FeedbackTypeNegative, updated.FeedbackType)
+}
+
+func (suite *FeedbackItemServiceTestSuite) TestUpdateFeedbackItemRejectsWrongPhase() {
+	updateFeedbackItemID := suite.seedFeedbackItem(suite.testAuthorID)
+	otherPhaseID := uuid.MustParse("34561b6b-3c3a-4bc6-ba42-69eeb1514da9")
+	req := feedbackItemDTO.UpdateFeedbackItemRequest{
+		FeedbackType: db.FeedbackTypeNegative,
+		FeedbackText: "Updated from another phase",
+	}
+
+	err := UpdateFeedbackItem(suite.suiteCtx, updateFeedbackItemID, otherPhaseID, suite.testAuthorID, req)
+	assert.ErrorIs(suite.T(), err, ErrFeedbackItemNotFound)
+}
+
+func (suite *FeedbackItemServiceTestSuite) TestUpdateFeedbackItemRejectsNonAuthor() {
+	// Feedback item 22222222 is authored by the lecturer, not testAuthorID
+	updateFeedbackItemID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	req := feedbackItemDTO.UpdateFeedbackItemRequest{
+		FeedbackType: db.FeedbackTypePositive,
+		FeedbackText: "Rewritten by a non-author",
+	}
+
+	err := UpdateFeedbackItem(suite.suiteCtx, updateFeedbackItemID, suite.testCoursePhaseID, suite.testAuthorID, req)
+	assert.ErrorIs(suite.T(), err, ErrNotFeedbackItemAuthor)
+
+	unchanged, err := GetFeedbackItem(suite.suiteCtx, updateFeedbackItemID)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), "Need to improve time management", unchanged.FeedbackText)
 }
 
 func (suite *FeedbackItemServiceTestSuite) TestGetFeedbackItem() {

--- a/servers/assessment/evaluations/router.go
+++ b/servers/assessment/evaluations/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	promptSDK "github.com/prompt-edu/prompt-sdk"
 	"github.com/prompt-edu/prompt/servers/assessment/assessmentType"
+	"github.com/prompt-edu/prompt/servers/assessment/coursePhaseConfig"
 	"github.com/prompt-edu/prompt/servers/assessment/evaluations/evaluationCompletion"
 	"github.com/prompt-edu/prompt/servers/assessment/evaluations/evaluationDTO"
 	"github.com/prompt-edu/prompt/servers/assessment/utils"
@@ -184,6 +185,7 @@ func getMyEvaluations(c *gin.Context) {
 // @Success 201 {string} string "Created"
 // @Failure 400 {object} map[string]string
 // @Failure 403 {object} map[string]string
+// @Failure 409 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /course_phase/{coursePhaseID}/evaluation [post]
 func createOrUpdateEvaluation(c *gin.Context) {
@@ -208,11 +210,7 @@ func createOrUpdateEvaluation(c *gin.Context) {
 
 	err = CreateOrUpdateEvaluation(c, coursePhaseID, request)
 	if err != nil {
-		if errors.Is(err, evaluationCompletion.ErrInvalidEvaluationType) || errors.Is(err, evaluationCompletion.ErrSelfEvaluationTargetMismatch) {
-			handleError(c, http.StatusBadRequest, err)
-			return
-		}
-		handleError(c, http.StatusInternalServerError, err)
+		handleError(c, evaluationErrorStatus(err), err)
 		return
 	}
 	c.Status(http.StatusCreated)
@@ -227,6 +225,7 @@ func createOrUpdateEvaluation(c *gin.Context) {
 // @Success 200 {string} string "OK"
 // @Failure 400 {object} map[string]string
 // @Failure 403 {object} map[string]string
+// @Failure 409 {object} map[string]string
 // @Failure 500 {object} map[string]string
 // @Router /course_phase/{coursePhaseID}/evaluation/{evaluationID} [delete]
 func deleteEvaluation(c *gin.Context) {
@@ -252,10 +251,24 @@ func deleteEvaluation(c *gin.Context) {
 
 	err = DeleteEvaluation(c, evaluationID)
 	if err != nil {
-		handleError(c, http.StatusInternalServerError, err)
+		handleError(c, evaluationErrorStatus(err), err)
 		return
 	}
 	c.Status(http.StatusOK)
+}
+
+func evaluationErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, coursePhaseConfig.ErrNotStarted):
+		return http.StatusForbidden
+	case errors.Is(err, evaluationCompletion.ErrEvaluationAlreadyCompleted):
+		return http.StatusConflict
+	case errors.Is(err, evaluationCompletion.ErrInvalidEvaluationType),
+		errors.Is(err, evaluationCompletion.ErrSelfEvaluationTargetMismatch):
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
 }
 
 func isEvaluationAuthor(c *gin.Context, evaluationID, authorID uuid.UUID) bool {


### PR DESCRIPTION
## Summary

Both student-facing feedback item endpoints trusted identity fields from the request body. `POST /evaluation/feedback-items` validated only the author and took the target `courseParticipationID` from the body, so an enrolled student could file `type: self` feedback attributed to any peer in the phase. `PUT /evaluation/feedback-items/:feedbackItemID` performed no ownership check on the stored row at all, so knowing an item ID was enough to overwrite it and reassign its author and target.

## Details

**Create (`createFeedbackItem`)**

- `CreateFeedbackItem` now runs inside a transaction and calls `evaluationCompletion.CheckEvaluationIsEditable` before the insert, the same gate `CreateOrUpdateEvaluation` already used. This enforces three things the endpoint previously skipped:
  - a `type: self` record must target its author (`ErrSelfEvaluationTargetMismatch`),
  - `type: assessment` is rejected (`ErrInvalidEvaluationType`); no student flow produces it, so it was only ever forgeable,
  - the evaluation window must have started and the author's completion must not be locked.

**Update (`updateFeedbackItem`)**

- The handler now takes the item ID from the URL instead of the body, and derives the author from the JWT.
- `UpdateFeedbackItem` loads the stored row in the transaction and rejects it when the phase does not match the URL (`404`) or the caller is not the stored author (`403`), then applies the same editability gate using the row's own target and type.
- `UpdateFeedbackItem` in `db/query/feedback_item.sql` matches on `id`, `course_phase_id` and `author_course_participation_id` and now writes only `feedback_type` and `feedback_text`. The identity columns (`course_participation_id`, `author_course_participation_id`, `course_phase_id`, `type`) are no longer writable, so they cannot be reassigned by a client. Regenerated `db/sqlc`; the query is now `:execrows` and a zero row count maps to `404`.
- `UpdateFeedbackItemRequest` drops `id`, `courseParticipationID`, `coursePhaseID`, `authorCourseParticipationID` and `type` — every one of them is now derived from the URL, the JWT or the stored row. The existing client already sends the ID in the URL and the remaining fields are simply ignored, so this is backward compatible.

**Tests**

- `TestCreateFeedbackItemValid` previously asserted `201` for a `type: self` payload whose target was a different student than the author, i.e. it pinned the vulnerability as expected behavior. It now uses a matching target, and `TestCreateFeedbackItemSelfTargetMismatch` asserts the attack payload gets `400`.
- Added coverage for the forged `type: assessment` create, and for update against a non-authored item (`403`), a foreign phase (`404`) and an unknown ID (`404`), each asserting the stored row is unchanged.
- Update tests seed their own rows rather than relying on suite method ordering.
- `database_dumps/feedbackItems.sql` gains `assessment_schema`, `course_phase_config` and `evaluation_completion`, which the newly wired editability check reads.

**Notes for the reviewer**

- Two pre-existing gaps are deliberately left alone here, since they apply equally to `POST /evaluation` and belong in their own change: `coursePhaseConfig.ErrNotStarted` maps to `500` rather than a 4xx, and `CheckEvaluationIsEditable` gates on the evaluation *start* and the completion flag but not on the deadline, so a student who never marks complete can still write after it passes.
- `type: peer` and `type: tutor` records still accept any target in the phase. That is the subject of a separate PR.

## Reason / Link to issue

Found during a security review of the assessment service. The same class of defect was fixed for `POST /evaluation` in #1790, but that change did not touch the feedback item package, which shares the target/author model and both write primitives exposed to students.

## How to Test

1. `cd servers/assessment && go test ./evaluations/...`
2. As an enrolled student, `POST /assessment/api/course_phase/<phase>/evaluation/feedback-items` with your own `authorCourseParticipationID` and a peer's `courseParticipationID` and `"type": "self"`. Expect `400` (previously `201`).
3. `PUT /assessment/api/course_phase/<phase>/evaluation/feedback-items/<id>` against an item authored by somebody else. Expect `403`, and confirm the row is untouched.
4. Confirm the normal flow still works: open the self, peer and tutor evaluation pages, add a comment, edit it, and delete it.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added assessment configuration and evaluation completion data to test environments.
  * Feedback items can now be updated with simplified request fields.
  * Updates validate item ownership and course phase, and report not-found errors.

* **Bug Fixes**
  * Prevented unauthorized, mismatched, or invalid feedback updates.
  * Added validation for self-evaluation targets and unsupported assessment types.

* **Documentation**
  * Updated API documentation to reflect the streamlined update request and 404 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->