### PR TITLE
`General`: Bump version to 2.16.0 for all components

### DIFF
--- a/clients/assessment_component/package.json
+++ b/clients/assessment_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assessment_component",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/certificate_component/package.json
+++ b/clients/certificate_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certificate_component",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/core/package.json
+++ b/clients/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/example_component/package.json
+++ b/clients/example_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example_component",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/interview_component/package.json
+++ b/clients/interview_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interview_component",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/matching_component/package.json
+++ b/clients/matching_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matching_component",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/package.json
+++ b/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prompt-module-federation",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "private": true,
   "workspaces": {
     "packages": [

--- a/clients/self_team_allocation_component/package.json
+++ b/clients/self_team_allocation_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self_team_allocation_component",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/team_allocation_component/package.json
+++ b/clients/team_allocation_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team_allocation_component",
-  "version": "2.15.5",
+  "version": "2.16.0",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps the client version from `2.15.5` to `2.16.0` (one minor version) across all Module Federation
packages in preparation for the next release.

## Details

Updated the `version` field from `2.15.5` to `2.16.0` in all nine client `package.json` files, so the
workspace root and every remote stay in lockstep:

- `clients/package.json` (`prompt-module-federation` workspace root)
- `clients/core/package.json`
- `clients/assessment_component/package.json`
- `clients/certificate_component/package.json`
- `clients/example_component/package.json`
- `clients/interview_component/package.json`
- `clients/matching_component/package.json`
- `clients/self_team_allocation_component/package.json`
- `clients/team_allocation_component/package.json`

No other files change. `clients/yarn.lock` does not record workspace versions, so it needs no
regeneration, and no source, configuration, or documentation references the old version string.

## Reason / Link to issue

The `v2.16.0` release tag is derived from the `version` field in `clients/core/package.json`, so the
bump has to land before the release is drafted. A minor bump reflects the feature work merged since
`2.15.5` (no breaking changes).

## How to Test

1. Run `grep -H '"version"' clients/package.json clients/*/package.json` and confirm all nine files
   report `2.16.0`.
2. Run `make lint` and confirm it passes.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
