### PR TITLE
`Testing`: Claim the CSV import API spec in the core e2e shard

### DIFF
--- a/e2e/shards.json
+++ b/e2e/shards.json
@@ -16,6 +16,7 @@
         "/tests/api/courses\\.api\\.spec\\.ts$",
         "/tests/api/application-apply\\.api\\.spec\\.ts$",
         "/tests/api/application-files\\.api\\.spec\\.ts$",
+        "/tests/api/application-import\\.api\\.spec\\.ts$",
         "/tests/api/course-staff\\.api\\.spec\\.ts$"
       ]
     },


### PR DESCRIPTION
## Summary

Fixes the red pipeline on `main`: the e2e `partition` job rejects `e2e/shards.json` because no shard claims `tests/api/application-import.api.spec.ts`, so every shard is skipped and the `e2e` gate fails on all open PRs.

## Details

`e2e/shards.json` enumerates the `tests/api/*.api.spec.ts` files one by one and assigns each to the shard that owns its service. The CSV import spec came from a different branch than the sharding work, so it was never added to that list:

- #1961 added `e2e/tests/api/application-import.api.spec.ts`.
- #1968 landed a few hours later with `e2e/shards.json`, written before that spec existed.

Both branches were green in isolation; the partition only became invalid once both were on `main`. The spec covers a core-hosted endpoint (`POST /api/applications/:coursePhaseID/import`), so it belongs to the `core` shard alongside the other application API specs.

No extra guard is added on top of the existing check: `npm run check-shards` already detects this, and the failure mode here is a semantic conflict between two individually valid branches, which only a merge-time run on the updated base can catch.

## Reason / Link to issue

Closes #2047

## How to Test

1. `cd e2e && node scripts/shards.mjs check` — passes, reporting 54 specs across 8 shards (25 in `core`).
2. On `main` the same command fails with `/tests/api/application-import.api.spec.ts is not covered by any shard`.
3. In CI, the `e2e-tests / partition` job succeeds and the `core` shard now runs the import spec.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
