### PR TITLE
`Core`: System Status page fix CPM identification

### DIFF
--- a/clients/core/src/managementConsole/pages/SystemStatusPage/SystemStatusPage.tsx
+++ b/clients/core/src/managementConsole/pages/SystemStatusPage/SystemStatusPage.tsx
@@ -5,9 +5,13 @@ import { useGetCoursePhaseTypes } from './hooks/useGetCoursePhaseTypes'
 import type { CoursePhaseType } from './interfaces/coursePhaseType'
 import type { ServiceInfo } from './interfaces/serviceCapabilities'
 import { getServiceInfo } from './network/getServiceCapabilities'
+import { isRealMicroservice } from './utils/isRealMicroservice'
 
 export const SystemStatusPage = () => {
-  const { data: coursePhaseTypes = [] } = useGetCoursePhaseTypes()
+  const { data: allCoursePhaseTypes = [] } = useGetCoursePhaseTypes()
+  // Only phase types backed by their own microservice expose an `/info` endpoint to probe.
+  // Core-handled phase types (Application, Matching, DevOps Challenge) are not separate services.
+  const coursePhaseTypes = allCoursePhaseTypes.filter((cpt) => isRealMicroservice(cpt.baseUrl))
 
   const results = useQueries({
     queries: coursePhaseTypes.map((service) => {

--- a/clients/core/src/managementConsole/pages/SystemStatusPage/utils/isRealMicroservice.ts
+++ b/clients/core/src/managementConsole/pages/SystemStatusPage/utils/isRealMicroservice.ts
@@ -1,0 +1,13 @@
+/**
+ * Course phase types that are handled directly by the core server (e.g. Application, Matching,
+ * DevOps Challenge) have `baseUrl` set to "core" instead of a real service URL
+ * This function decides one from the other.
+ */
+export function isRealMicroservice(baseUrl: string): boolean {
+  try {
+    const parsed = new URL(baseUrl);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/clients/core/src/managementConsole/pages/SystemStatusPage/utils/isRealMicroservice.ts
+++ b/clients/core/src/managementConsole/pages/SystemStatusPage/utils/isRealMicroservice.ts
@@ -5,9 +5,9 @@
  */
 export function isRealMicroservice(baseUrl: string): boolean {
   try {
-    const parsed = new URL(baseUrl);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
+    const parsed = new URL(baseUrl)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
   } catch {
-    return false;
+    return false
   }
 }

--- a/clients/core/src/managementConsole/shared/components/Privacy/PrivacyServiceAvailability.tsx
+++ b/clients/core/src/managementConsole/shared/components/Privacy/PrivacyServiceAvailability.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useGetCoursePhaseTypes } from '../../../pages/SystemStatusPage/hooks/useGetCoursePhaseTypes'
 import { getServiceInfo } from '../../../pages/SystemStatusPage/network/getServiceCapabilities'
+import { isRealMicroservice } from '../../../pages/SystemStatusPage/utils/isRealMicroservice'
 
 enum PSAStatus {
   Loading = 'loading',
@@ -56,19 +57,10 @@ interface PrivacyServiceAvailabilityProps {
   forSelf?: boolean
 }
 
-function hasOwnMicroservice(baseUrl: string): boolean {
-  try {
-    const parsed = new URL(baseUrl)
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
-  } catch {
-    return false
-  }
-}
-
 export function PrivacyServiceAvailability({ forSelf }: PrivacyServiceAvailabilityProps = {}) {
   const { data: allCoursePhaseTypes = [], isPending: typesPending } =
     useGetCoursePhaseTypes(forSelf)
-  const coursePhaseTypes = allCoursePhaseTypes.filter((cpt) => hasOwnMicroservice(cpt.baseUrl))
+  const coursePhaseTypes = allCoursePhaseTypes.filter((cpt) => isRealMicroservice(cpt.baseUrl))
 
   const coreQuery = useQuery({
     queryKey: ['serviceInfo-core'],


### PR DESCRIPTION
## Summary

the system status page now uses the same filtering logic already used by export, deletion or other parts of the system
to identify which Course Phase Type records form the db are actual microservices.

## Details

The non microservices have 'core' as the base_url, instead of an actual URL.
These are simply filtered out now.

## Reason / Link to issue

- fix wrongly showing Course phase Type records, such as application in the system status page

## How to Test

- Inspect Admin's System status page to see Application alongside the other Core owned phases no longer appear.

## Screenshots

Notice see the correct presence. Locally, I didn't start all cpm's, hence they are unavailable (but not relevant)
<img width="2426" height="1678" alt="2026-08-15 at 09 16 26@2x" src="https://github.com/user-attachments/assets/0659eb4e-e2b0-4fe6-bb75-fd9ac7e4f23a" />


## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [x] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system status monitoring by checking only course phases backed by standalone HTTP(S) services.
  * Prevented invalid or unsupported service URLs from generating unnecessary status checks.
  * Applied consistent service filtering across system status and privacy availability views.
  * Reduced misleading availability results for course phases handled within the core application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->