### PR TITLE
`Infrastructure`: Fix Discord release notification hitting the webhook rate limit

### DIFF
--- a/.github/workflows/discord-release-notification.yml
+++ b/.github/workflows/discord-release-notification.yml
@@ -11,16 +11,33 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Send Discord Release Notification
-        uses: appleboy/discord-action@v1.2.0
-        with:
-          webhook_id: ${{ secrets.DISCORD_WEBHOOK_ID }}
-          webhook_token: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-          username: "PROMPT Release Bot"
-          avatar_url: "https://prompt.aet.cit.tum.de/img/prompt_logo.svg"
-          message: |
-            🎉 **PROMPT ${{ github.event.release.tag_name }} has been released!**
+      - name: Send Discord release notification
+        env:
+          WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
+          WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+        run: |
+          set -euo pipefail
 
-            ${{ github.event.release.body }}
+          payload=$(jq -n \
+            --arg tag "$RELEASE_TAG" \
+            --arg url "$RELEASE_URL" \
+            --arg body "$RELEASE_BODY" \
+            '
+            def clip($max):
+              if length <= $max then .
+              else (.[0:$max] | sub("\n[^\n]*$"; "") | sub("\\s+$"; "")) + "\n\n_(truncated)_"
+              end;
+            {
+              username: "PROMPT Release Bot",
+              avatar_url: "https://prompt.aet.cit.tum.de/img/prompt_logo.svg",
+              content: "🎉 **PROMPT \($tag) has been released!**\n\n\($body | clip(1500))\n\n👉 **Full release notes:** \($url)"
+            }')
 
-            👉 **Full release notes:** ${{ github.event.release.html_url }}
+          curl "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN" \
+            --silent --show-error --fail-with-body \
+            --retry 3 --retry-delay 2 --retry-max-time 60 \
+            --header "Content-Type: application/json" \
+            --data-binary "$payload"


### PR DESCRIPTION
## Summary

Every recent release notification has failed. The `Discord Release Notification` workflow was firing
one webhook request per comma in the release notes, tripping Discord's rate limit. It now posts the
notification as a single request.

## Details

`appleboy/discord-action@v1.2.0` runs `drone-discord`, which declares its `message` input as a
urfave/cli `StringSliceFlag`. urfave/cli splits string-slice values read from an environment variable
on `,`, so `INPUT_MESSAGE` arrives as a list of fragments and the plugin loops over them, POSTing
each one as a separate webhook request. There is no chunking, no delay, and no retry anywhere in the
plugin, at `1.4.1` or at the current `1.5.1`.

Replaying the real v2.16.1 message through a local build of the plugin against a request recorder
produced 19 POSTs in 7ms. Discord allows 5 per 2 seconds, so it returns `429 You are being rate
limited.` Counting the comma fragments in the message each run actually sent lines up exactly with
the outcome:

| Requests fired | Outcome | Release |
| --- | --- | --- |
| 5 | ok | v2.14.1 |
| 5 | ok | v2.15.4 |
| 6 | ok | v2.13.1 |
| 6 | `400` | v2.14.0 |
| 8 | `429` | v2.12.0 |
| 13 | `429` | v2.15.5 |
| 14 | `429` | v2.15.0 |
| 19 | `429` | v2.16.1 |
| 28 | `429` | v2.16.0 |

v2.14.0's `400` is the same bug from the other side: its fragments were 120, 16, 22, 62, 73 and 2704
characters, and the last one exceeded Discord's 2000 character content limit. The runs that did pass
were not healthy either. They posted the notes as five or six separate messages with every comma
silently deleted, and only stayed under both limits by luck.

The step now builds the payload with `jq` and posts it with a single `curl`:

- `jq --arg` takes the release body as data, so commas, quotes and backslashes survive intact.
- `clip(1500)` trims the body at a line boundary and appends `_(truncated)_`, keeping the message
  under the 2000 character limit. The full notes are already linked in the footer.
- `--fail-with-body` makes a non-2xx response fail the step and print Discord's error, instead of the
  action's previous behaviour of failing without useful context.
- `--retry 3` covers a genuinely transient `429` or 5xx. curl honours `Retry-After`, and does not
  retry a `400`.

Upgrading the action was not an option: `v1.2.0` is its newest tag, and the `StringSliceFlag`
declaration is unchanged in the latest `drone-discord`.

`.github/workflows/discord-notifications.yml` (the PR review ping) uses the same action and has the
same latent bug. Its message contains only one or two commas so it stays under the limit, though it
does drop them from PR titles. Left out of this PR to keep the change focused.

## Reason / Link to issue

The release notification has failed on v2.16.1, v2.16.0 and v2.15.5, and intermittently before that
as the release notes grew longer.

## How to Test

The workflow only triggers on `release: published`, so it was verified by running the step against a
local HTTP recorder standing in for the Discord webhook.

1. Start a local server on `127.0.0.1:8792` that logs each POST body and returns `204`.
2. Extract the `run:` block from `.github/workflows/discord-release-notification.yml` and point the
   `curl` URL at it.
3. Export `RELEASE_TAG`, `RELEASE_URL` and `RELEASE_BODY` from a real release
   (`gh release view v2.16.0 --json body -q .body`) and run the script.

Result: one request per release instead of 28, every payload between 366 and 1612 characters, and
the step exits `0`. Repeating with the recorder returning `429` shows the retries and a non-zero exit;
with `400` it fails immediately without retrying.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
