### PR TITLE
`UI/UX`: Replace inline loading spinners with the shared LoadingPage

### DIFF
--- a/clients/assessment_component/src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentParticipantsPage/AssessmentParticipantsPage.tsx
@@ -3,10 +3,10 @@ import {
   CoursePhaseParticipationsTable,
   ErrorPage,
   type ExtraParticipantColumn,
+  LoadingPage,
   ManagementPageHeader,
   type TableFilter,
 } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
 import { useMemo, useRef } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { AssessmentType } from '../../interfaces/assessmentType'
@@ -161,11 +161,7 @@ export const AssessmentParticipantsPage = () => {
     return <ErrorPage message='Error loading assessments' onRetry={refetch} />
   }
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   return (

--- a/clients/assessment_component/src/assessment/pages/AssessmentStatisticsPage/AssessmentStatisticsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/AssessmentStatisticsPage/AssessmentStatisticsPage.tsx
@@ -1,5 +1,4 @@
-import { ErrorPage, ManagementPageHeader } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
+import { ErrorPage, LoadingPage, ManagementPageHeader } from '@tumaet/prompt-ui-components'
 import { useMemo, useState } from 'react'
 import { AssessmentDisabledNotice } from '../components/AssessmentDisabledNotice'
 import { AuthorDiagram } from '../components/diagrams/AuthorDiagram'
@@ -100,11 +99,7 @@ export const AssessmentStatisticsPage = () => {
     return <ErrorPage message='Error loading assessments' onRetry={refetch} />
   }
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
   if (!assessmentEnabled) {
     return <AssessmentDisabledNotice title='Assessment Statistics' />

--- a/clients/assessment_component/src/assessment/pages/EvaluationParticipantResultsPage/EvaluationParticipantResultsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/EvaluationParticipantResultsPage/EvaluationParticipantResultsPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
-import { Button, Card, CardContent, ErrorPage } from '@tumaet/prompt-ui-components'
-import { Loader2, Printer } from 'lucide-react'
+import { Button, Card, CardContent, ErrorPage, LoadingPage } from '@tumaet/prompt-ui-components'
+import { Printer } from 'lucide-react'
 import { type ReactNode, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -136,11 +136,7 @@ export const EvaluationParticipantResultsPage = ({
   }
 
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   if (!participant) {

--- a/clients/assessment_component/src/assessment/pages/EvaluationParticipantResultsPage/EvaluationParticipantsOverviewPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/EvaluationParticipantResultsPage/EvaluationParticipantsOverviewPage.tsx
@@ -1,7 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
 import type { ColumnDef } from '@tanstack/react-table'
 import type { Team } from '@tumaet/prompt-shared-state'
-import { Button, ErrorPage, ManagementPageHeader, PromptTable } from '@tumaet/prompt-ui-components'
+import {
+  Button,
+  ErrorPage,
+  LoadingPage,
+  ManagementPageHeader,
+  PromptTable,
+} from '@tumaet/prompt-ui-components'
 import { Loader2, Printer } from 'lucide-react'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
@@ -218,11 +224,7 @@ export const EvaluationParticipantsOverviewPage = ({
   }
 
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   return (

--- a/clients/assessment_component/src/assessment/pages/TutorEvaluationResultsPage/TutorEvaluationResultsPage.tsx
+++ b/clients/assessment_component/src/assessment/pages/TutorEvaluationResultsPage/TutorEvaluationResultsPage.tsx
@@ -1,5 +1,5 @@
-import { Button, Card, CardContent, ErrorPage } from '@tumaet/prompt-ui-components'
-import { ChevronLeft, ChevronRight, Loader2, Printer } from 'lucide-react'
+import { Button, Card, CardContent, ErrorPage, LoadingPage } from '@tumaet/prompt-ui-components'
+import { ChevronLeft, ChevronRight, Printer } from 'lucide-react'
 import { useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { AssessmentType } from '../../interfaces/assessmentType'
@@ -92,12 +92,7 @@ export const TutorEvaluationResultsPage = () => {
   )
 
   if (isError) return <ErrorPage onRetry={refetch} />
-  if (isPending)
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+  if (isPending) return <LoadingPage />
 
   if (!tutor) {
     return <ErrorPage message='The requested tutor could not be found.' />

--- a/clients/certificate_component/src/certificate/pages/ParticipantsPage.tsx
+++ b/clients/certificate_component/src/certificate/pages/ParticipantsPage.tsx
@@ -3,11 +3,12 @@ import {
   CoursePhaseParticipationsTable,
   ErrorPage,
   type ExtraParticipantColumn,
+  LoadingPage,
   ManagementPageHeader,
   type ParticipantRow,
   type RowAction,
 } from '@tumaet/prompt-ui-components'
-import { CheckCircle2, Download, Loader2, XCircle } from 'lucide-react'
+import { CheckCircle2, Download, XCircle } from 'lucide-react'
 import { useCallback, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 
@@ -141,11 +142,7 @@ export const ParticipantsPage = () => {
   }
 
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   const downloadedCount = participants?.filter((p) => p.hasDownloaded).length ?? 0

--- a/clients/certificate_component/src/certificate/pages/SettingsPage.tsx
+++ b/clients/certificate_component/src/certificate/pages/SettingsPage.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
   DatePicker,
   ErrorPage,
+  LoadingPage,
   ManagementPageHeader,
   Popover,
   PopoverContent,
@@ -229,11 +230,7 @@ export const SettingsPage = () => {
   }
 
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   return (

--- a/clients/certificate_component/src/certificate/pages/StudentOverviewPage.tsx
+++ b/clients/certificate_component/src/certificate/pages/StudentOverviewPage.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
   ErrorPage,
+  LoadingPage,
   ManagementPageHeader,
   useToast,
 } from '@tumaet/prompt-ui-components'
@@ -59,11 +60,7 @@ export const StudentOverviewPage = () => {
   }
 
   if (isLoading) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   return (

--- a/clients/core/src/managementConsole/applicationAdministration/components/ApplicationDataWrapper.tsx
+++ b/clients/core/src/managementConsole/applicationAdministration/components/ApplicationDataWrapper.tsx
@@ -1,8 +1,7 @@
 import { getAdditionalScoreNames } from '@core/network/queries/additionalScoreNames'
 import { useQuery } from '@tanstack/react-query'
 import { useGetCoursePhase } from '@tumaet/prompt-shared-state'
-import { ErrorPage } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
+import { ErrorPage, LoadingPage } from '@tumaet/prompt-ui-components'
 import { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { useGetApplicationParticipations } from '../hooks/useGetApplicationParticipations'
@@ -68,17 +67,5 @@ export const ApplicationDataWrapper = ({ children }: ApplicationDataWrapperProps
     }
   }, [fetchedCoursePhase, setCoursePhase])
 
-  return (
-    <>
-      {isError ? (
-        <ErrorPage onRetry={refetch} />
-      ) : isPending ? (
-        <div className='flex justify-center items-center grow'>
-          <Loader2 className='h-12 w-12 animate-spin text-primary' />
-        </div>
-      ) : (
-        children
-      )}
-    </>
-  )
+  return <>{isError ? <ErrorPage onRetry={refetch} /> : isPending ? <LoadingPage /> : children}</>
 }

--- a/clients/core/src/managementConsole/courseConfigurator/CourseConfiguratorPage.tsx
+++ b/clients/core/src/managementConsole/courseConfigurator/CourseConfiguratorPage.tsx
@@ -1,5 +1,4 @@
-import { Card, ErrorPage, ManagementPageHeader } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
+import { Card, ErrorPage, LoadingPage, ManagementPageHeader } from '@tumaet/prompt-ui-components'
 import { Canvas } from './Canvas'
 import { HelpDialog } from './components/HelpDialog'
 import { useCourseConfiguratorDataSetup } from './handlers/useCourseConfiguratorDataSetup'
@@ -25,9 +24,7 @@ export default function CourseConfiguratorPage() {
             onRetry={() => refetchAll()}
           />
         ) : isPending || !finishedSetup ? (
-          <div className='flex justify-center items-center h-64'>
-            <Loader2 className='h-12 w-12 animate-spin text-primary' />
-          </div>
+          <LoadingPage />
         ) : (
           <Canvas />
         )}

--- a/clients/example_component/src/example_component/pages/ParticipantsPage.tsx
+++ b/clients/example_component/src/example_component/pages/ParticipantsPage.tsx
@@ -2,9 +2,9 @@ import { useGetCoursePhaseParticipants } from '@tumaet/prompt-shared-state'
 import {
   CoursePhaseParticipationsTable,
   ErrorPage,
+  LoadingPage,
   ManagementPageHeader,
 } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
 import { useParams } from 'react-router-dom'
 
 export const ParticipantsPage = () => {
@@ -18,12 +18,7 @@ export const ParticipantsPage = () => {
   } = useGetCoursePhaseParticipants()
 
   if (isError) return <ErrorPage onRetry={refetch} description='Could not fetch participants' />
-  if (isPending)
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+  if (isPending) return <LoadingPage />
 
   return (
     <div id='table-view' className='relative flex flex-col'>

--- a/clients/example_component/src/example_component/pages/SettingsPage.tsx
+++ b/clients/example_component/src/example_component/pages/SettingsPage.tsx
@@ -1,6 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
-import { Card, CardContent, ErrorPage, ManagementPageHeader } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
+import {
+  Card,
+  CardContent,
+  ErrorPage,
+  LoadingPage,
+  ManagementPageHeader,
+} from '@tumaet/prompt-ui-components'
 import { useParams } from 'react-router-dom'
 import { getExampleInfo } from '../network/queries/getExampleInfo'
 
@@ -21,12 +26,7 @@ export const SettingsPage = () => {
     return (
       <ErrorPage onRetry={refetchExampleInfo} description='Could not fetch example information' />
     )
-  if (isExampleInfoPending)
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+  if (isExampleInfoPending) return <LoadingPage />
 
   return (
     <div>

--- a/clients/interview_component/src/interview/pages/InterviewDataShell.tsx
+++ b/clients/interview_component/src/interview/pages/InterviewDataShell.tsx
@@ -5,8 +5,7 @@ import {
   getCoursePhase,
   getCoursePhaseParticipations,
 } from '@tumaet/prompt-shared-state'
-import { ErrorPage } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
+import { ErrorPage, LoadingPage } from '@tumaet/prompt-ui-components'
 import { useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import type { InterviewSlot, InterviewSlotWithAssignments } from '../interfaces/InterviewSlots'
@@ -101,17 +100,5 @@ export const InterviewDataShell = ({ children }: InterviewDataShellProps) => {
     }
   }, [interviewSlotsWithAssignments, setInterviewSlots])
 
-  return (
-    <>
-      {isError ? (
-        <ErrorPage onRetry={refetch} />
-      ) : isPending ? (
-        <div className='flex justify-center items-center h-64'>
-          <Loader2 className='h-12 w-12 animate-spin text-primary' />
-        </div>
-      ) : (
-        children
-      )}
-    </>
-  )
+  return <>{isError ? <ErrorPage onRetry={refetch} /> : isPending ? <LoadingPage /> : children}</>
 }

--- a/clients/interview_component/src/interview/pages/InterviewParticipantsPage/InterviewParticipantsPage.tsx
+++ b/clients/interview_component/src/interview/pages/InterviewParticipantsPage/InterviewParticipantsPage.tsx
@@ -2,9 +2,9 @@ import { useGetCoursePhaseParticipants } from '@tumaet/prompt-shared-state'
 import {
   CoursePhaseParticipationsTable,
   ErrorPage,
+  LoadingPage,
   ManagementPageHeader,
 } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
 import { useParams } from 'react-router-dom'
 
 export const InterviewParticipantsPage = () => {
@@ -23,9 +23,7 @@ export const InterviewParticipantsPage = () => {
       {isError ? (
         <ErrorPage onRetry={refetch} />
       ) : isPending ? (
-        <div className='flex justify-center items-center h-64'>
-          <Loader2 className='h-12 w-12 animate-spin text-primary' />
-        </div>
+        <LoadingPage />
       ) : (
         <CoursePhaseParticipationsTable
           phaseId={phaseId!}

--- a/clients/matching_component/src/matching/MatchingOverviewPage.tsx
+++ b/clients/matching_component/src/matching/MatchingOverviewPage.tsx
@@ -11,10 +11,11 @@ import {
   CardHeader,
   CardTitle,
   ErrorPage,
+  LoadingPage,
   ManagementPageHeader,
   Separator,
 } from '@tumaet/prompt-ui-components'
-import { ClipboardList, FileUp, Loader2, UserRoundCheck } from 'lucide-react'
+import { ClipboardList, FileUp, UserRoundCheck } from 'lucide-react'
 import { useEffect } from 'react'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { UploadButton } from './components/UploadButton'
@@ -53,9 +54,7 @@ export const MatchingOverviewPage = () => {
       {isParticipationsError ? (
         <ErrorPage onRetry={refetchCoursePhaseParticipations} />
       ) : isCoursePhaseParticipationsPending ? (
-        <div className='flex justify-center items-center h-64'>
-          <Loader2 className='h-12 w-12 animate-spin text-primary' />
-        </div>
+        <LoadingPage />
       ) : (
         <div>
           <div className='grid md:grid-cols-2 gap-8'>

--- a/clients/matching_component/src/matching/pages/MatchingParticipantsPage/MatchingParticipantsPage.tsx
+++ b/clients/matching_component/src/matching/pages/MatchingParticipantsPage/MatchingParticipantsPage.tsx
@@ -2,9 +2,9 @@ import { useGetCoursePhaseParticipants } from '@tumaet/prompt-shared-state'
 import {
   CoursePhaseParticipationsTable,
   ErrorPage,
+  LoadingPage,
   ManagementPageHeader,
 } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
 import { useParams } from 'react-router-dom'
 
 export const MatchingParticipantsPage = () => {
@@ -23,9 +23,7 @@ export const MatchingParticipantsPage = () => {
       {isError ? (
         <ErrorPage onRetry={refetch} />
       ) : isPending ? (
-        <div className='flex justify-center items-center h-64'>
-          <Loader2 className='h-12 w-12 animate-spin text-primary' />
-        </div>
+        <LoadingPage />
       ) : (
         <CoursePhaseParticipationsTable
           phaseId={phaseId!}

--- a/clients/self_team_allocation_component/src/self_team_allocation/pages/SelfTeamAllocationParticipantsPage/SelfTeamAllocationParticipantsPage.tsx
+++ b/clients/self_team_allocation_component/src/self_team_allocation/pages/SelfTeamAllocationParticipantsPage/SelfTeamAllocationParticipantsPage.tsx
@@ -4,9 +4,9 @@ import {
   CoursePhaseParticipationsTable,
   ErrorPage,
   type ExtraParticipantColumn,
+  LoadingPage,
   ManagementPageHeader,
 } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { getAllTeams } from '../../network/queries/getAllTeams'
@@ -92,12 +92,7 @@ export const SelfTeamAllocationParticipantsPage = () => {
 
   if (isError)
     return <ErrorPage onRetry={refetch} description='Could not fetch participants or teams' />
-  if (isPending)
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+  if (isPending) return <LoadingPage />
 
   return (
     <div id='table-view' className='relative flex flex-col'>

--- a/clients/self_team_allocation_component/src/self_team_allocation/pages/TeamAllocation/SelfTeamAllocationPage.tsx
+++ b/clients/self_team_allocation_component/src/self_team_allocation/pages/TeamAllocation/SelfTeamAllocationPage.tsx
@@ -13,9 +13,10 @@ import {
   AlertDescription,
   AlertTitle,
   ErrorPage,
+  LoadingPage,
   UnauthorizedPage,
 } from '@tumaet/prompt-ui-components'
-import { Loader2, TriangleAlert } from 'lucide-react'
+import { TriangleAlert } from 'lucide-react'
 import { useParams } from 'react-router-dom'
 import type { Timeframe } from '../../interfaces/timeframe'
 import { getAllTeams } from '../../network/queries/getAllTeams'
@@ -73,11 +74,7 @@ export const SelfTeamAllocationPage = () => {
   }
 
   if (isTeamsPending || (isStudent && isPending)) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   if (isStudent && isError) {

--- a/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/SurveySettingsPage.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/SurveySettings/SurveySettingsPage.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import type { Team } from '@tumaet/prompt-shared-state'
 import {
   ErrorPage,
+  LoadingPage,
   ManagementPageHeader,
   MissingSettings,
   type MissingSettingsItem,
@@ -120,11 +121,7 @@ export const SurveySettingsPage = () => {
   }
 
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center grow'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   return (

--- a/clients/team_allocation_component/src/team_allocation/pages/TeamAllocation/TeamAllocationPage.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/TeamAllocation/TeamAllocationPage.tsx
@@ -14,10 +14,11 @@ import {
   CardContent,
   CardHeader,
   ErrorPage,
+  LoadingPage,
   ManagementPageHeader,
   Separator,
 } from '@tumaet/prompt-ui-components'
-import { Loader2, Users } from 'lucide-react'
+import { Users } from 'lucide-react'
 import type React from 'react'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
@@ -94,11 +95,7 @@ export const TeamAllocationPage: React.FC = () => {
   const isError = isTeamsError || isParticipationsError || isTeamAllocationsError
 
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   if (isError) {

--- a/clients/team_allocation_component/src/team_allocation/pages/TeamAllocationParticipantsPage/TeamAllocationParticipantsPage.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/TeamAllocationParticipantsPage/TeamAllocationParticipantsPage.tsx
@@ -4,9 +4,9 @@ import {
   CoursePhaseParticipationsTable,
   ErrorPage,
   type ExtraParticipantColumn,
+  LoadingPage,
   ManagementPageHeader,
 } from '@tumaet/prompt-ui-components'
-import { Loader2 } from 'lucide-react'
 import { useEffect, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import type { Allocation } from '../../interfaces/allocation'
@@ -135,12 +135,7 @@ export const TeamAllocationParticipantsPage = () => {
   if (!phaseId) return <ErrorPage onRetry={refetch} description='Invalid course phase ID' />
   if (isError)
     return <ErrorPage onRetry={refetch} description='Could not fetch participants or teams' />
-  if (isPending)
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+  if (isPending) return <LoadingPage />
 
   return (
     <div id='table-view' className='relative flex flex-col'>

--- a/clients/team_allocation_component/src/team_allocation/pages/TeaseConfig/components/StudentDataCheck.tsx
+++ b/clients/team_allocation_component/src/team_allocation/pages/TeaseConfig/components/StudentDataCheck.tsx
@@ -4,12 +4,13 @@ import {
   Card,
   CardContent,
   ErrorPage,
+  LoadingPage,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from '@tumaet/prompt-ui-components'
-import { ArrowRight, Loader2, Users } from 'lucide-react'
+import { ArrowRight, Users } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import type { TeaseStudent } from '../../../interfaces/tease/student'
@@ -77,11 +78,7 @@ export const StudentDataCheck = () => {
   }, [students])
 
   if (isPending) {
-    return (
-      <div className='flex justify-center items-center h-64'>
-        <Loader2 className='h-12 w-12 animate-spin text-primary' />
-      </div>
-    )
+    return <LoadingPage />
   }
 
   if (isError) {


### PR DESCRIPTION
## Summary

Replaces the hand-rolled full-page loading spinner (`<div className='flex justify-center items-center h-64'><Loader2 className='h-12 w-12 animate-spin text-primary' /></div>`) with the shared `LoadingPage` component from `@tumaet/prompt-ui-components`, which several pages already use.

## Details

- 22 page-level and data-shell loading gates across core and all seven phase components now render `<LoadingPage />` instead of an inline spinner block.
- Removed the resulting unused `Loader2` imports; files that still use `Loader2` for button or badge spinners keep it.
- No dependency change: `LoadingPage` is already exported by the installed `@tumaet/prompt-ui-components`.
- Deliberately left untouched, because a viewport-sized loader would be wrong there:
  - Nested panels and sections that render alongside sibling content (`ActionItemPanel`, `FeedbackItemsPanel`, `FeedbackItemPanel`, `AssessmentResultsSection`, `EvaluationResultsSection`). `FeedbackItemsPanel` also carries its own `role='status'` and screen-reader text.
  - Dialog-scoped loaders (`ApplicationManualAddingDialog`, `ApplicationDetailsPage`, `StudentDetailDialog`).
  - Loaders with extra copy or a different layout (`StudentSurveyPage`, `QuestionConfiguration`).
  - All inline button, badge, and small icon spinners.

## Reason / Link to issue

The same spinner markup was duplicated across every component while a shared component for it already exists, so any future change to the loading state had to be made in 22 places.

Closes #1980

## How to Test

1. Start the clients and the core server (`make clients`, `make servers`).
2. Open a course and visit the participants, settings, and statistics pages of the assessment, certificate, interview, matching, team allocation, and self team allocation phases.
3. Throttle the network (or reload with a cold cache) and confirm a centered spinner appears while the data loads and the page renders normally afterwards.
4. Open the course configurator and an application administration page and confirm the same.

## Screenshots

Not applicable: the rendered spinner is the same `Loader2` icon, only the wrapper it is centered in changes.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized loading screens across assessment, certificate, interview, matching, team allocation, and other application areas.
  * Replaced page-specific spinners with a consistent loading experience.
* **Bug Fixes**
  * Preserved existing error handling and content while improving pending-state presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->