### PR TITLE
`Testing`: Retry the e2e blob report download and gate the dev deploy on e2e

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -89,7 +89,7 @@ jobs:
     uses: ./.github/workflows/build-and-push-clients.yml
     secrets: inherit
   deploy-dev:
-    needs: [build-clients, build-servers]
+    needs: [build-clients, build-servers, e2e-tests]
     uses: ./.github/workflows/deploy-docker.yml
     secrets: inherit
     with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -142,6 +142,24 @@ jobs:
         working-directory: e2e
 
       - name: Download all blob reports
+        id: download
+        # Artifact storage occasionally drops one blob mid-download; retried below.
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: blob-report-*
+          path: e2e/all-blob-reports
+          merge-multiple: true
+
+      # A failed download streams straight into the target directory, so a
+      # truncated report can survive and break the merge.
+      - name: Clear the partial download before retrying
+        if: ${{ steps.download.outcome == 'failure' }}
+        run: rm -rf e2e/all-blob-reports
+
+      # No continue-on-error: a second miss is a real failure and reddens the gate.
+      - name: Retry the blob report download
+        if: ${{ steps.download.outcome == 'failure' }}
         uses: actions/download-artifact@v8
         with:
           pattern: blob-report-*

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -86,10 +86,13 @@ fans it out for wall-clock:
    `PW_BLOB=1` to emit a per-shard blob report. Each shard runs with **1 worker**
    (`workers: 1`); parallelism comes from the matrix, not from within a shard.
 3. A **merge** job downloads the blob reports and merges them into the single
-   `playwright-report` artifact (`npm run merge-reports`).
+   `playwright-report` artifact (`npm run merge-reports`). Artifact storage
+   occasionally drops a single blob mid-download, so the download gets one clean
+   retry; a second miss fails the job.
 4. An **e2e** job fails unless all of the above succeeded. It exists purely to
    give branch protection one required check (`e2e-tests / e2e`) whose name does
-   not change when a shard is added or renamed.
+   not change when a shard is added or renamed. `deploy-dev` waits on this
+   workflow, so a red suite stops the dev deployment.
 
 There is deliberately **no build-once job** in front of the shards. Serializing a
 full build ahead of shards that then rebuild anyway only adds wall-clock; what


### PR DESCRIPTION
## Summary

Stops a transient GitHub artifact-storage flake from reddening the required `e2e-tests / e2e` check, and makes the dev deployment wait for the e2e suite instead of ignoring it.

## Details

- `test-e2e.yml`, `merge` job: the blob report download now gets one clean retry. The first attempt is `continue-on-error`, the retry wipes `e2e/all-blob-reports` first (a failed download streams straight into that directory, so a truncated `report-*.zip` can survive and break `merge-reports`), and the retry itself is hard-failing so a second miss still fails the gate. `merge` stays part of the `e2e` verdict.
- `dev.yml`: `deploy-dev` now needs `e2e-tests` in addition to `build-clients` and `build-servers`. Until now a red e2e suite did not stop the dev deployment.
- `e2e/README.md`: documented both.

## Reason / Link to issue

The last two `Build and Deploy to Dev` runs on `main` (32398894190 and 32170827195) went red on `e2e-tests / merge` while all eight shards passed. In both, seven of eight blob reports downloaded in under a second and the eighth failed after the action's five internal retries:

```
7x "Artifact download completed successfully."
##[error]Unable to download artifact(s): Unable to download and extract artifact:
Artifact download failed after 5 retries.
```

The artifact is not corrupt: `gh run download` pulled the same `blob-report-assessment` afterwards and it extracted fine. It is a transient blob-storage failure in a report-only job, and it blocks merges because `e2e-tests / e2e` is a required check.

## How to Test

1. Open this PR and confirm `e2e-tests / merge` still downloads all eight blob reports on the first attempt, skipping both retry steps.
2. Confirm `deploy-dev` now lists `e2e-tests` among its dependencies and waits for the suite.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end test report handling by retrying failed artifact downloads once before failing.
  - Prevented development deployments from proceeding until end-to-end tests complete successfully.

- **Documentation**
  - Updated CI documentation to describe artifact download retries and deployment safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->