### PR TITLE
`General`: Bump version to 2.16.2 for all components

### DIFF
--- a/clients/assessment_component/package.json
+++ b/clients/assessment_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assessment_component",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/certificate_component/package.json
+++ b/clients/certificate_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "certificate_component",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/core/package.json
+++ b/clients/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/example_component/package.json
+++ b/clients/example_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example_component",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/interview_component/package.json
+++ b/clients/interview_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interview_component",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/matching_component/package.json
+++ b/clients/matching_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matching_component",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/package.json
+++ b/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prompt-module-federation",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "private": true,
   "workspaces": {
     "packages": [

--- a/clients/self_team_allocation_component/package.json
+++ b/clients/self_team_allocation_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "self_team_allocation_component",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {

--- a/clients/team_allocation_component/package.json
+++ b/clients/team_allocation_component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "team_allocation_component",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "main": "src/index.ts",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps the client version from `2.16.1` to `2.16.2` (one patch version) across all Module Federation
packages in preparation for the next patch release.

## Details

Updated the `version` field from `2.16.1` to `2.16.2` in all nine client `package.json` files, so the
workspace root and every remote stay in lockstep:

- `clients/package.json` (`prompt-module-federation` workspace root)
- `clients/core/package.json`
- `clients/assessment_component/package.json`
- `clients/certificate_component/package.json`
- `clients/example_component/package.json`
- `clients/interview_component/package.json`
- `clients/matching_component/package.json`
- `clients/self_team_allocation_component/package.json`
- `clients/team_allocation_component/package.json`

No other files change. A repo-wide search for the `2.16.1` string matches only these nine `version`
fields (the remaining hits are unrelated `is-core-module@2.16.1` entries in `docs/yarn.lock`), so no
source, configuration, or documentation reference needs updating. `clients/yarn.lock` does not record
workspace versions and therefore needs no regeneration.

The bump is kept as a single commit on purpose: the nine files have to move together, and splitting
them would leave intermediate commits where the workspace root and the remotes disagree.

## Reason / Link to issue

The release tag is derived from the `version` field in `clients/core/package.json`, so the bump has to
land before the release is drafted. A patch bump reflects that the work merged since `2.16.1` contains
no new features or breaking changes.

## How to Test

1. Run `grep -H '"version"' clients/package.json clients/*/package.json` and confirm all nine files
   report `2.16.2`.
2. Run `make lint` and confirm it passes.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the client package suite to version 2.16.2.
  * Synchronized version numbers across assessment, certificate, interview, matching, allocation, example, and core components.
  * No user-facing functionality or public API changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->