### PR TITLE
`Core`: Fix the overlapping search icon and spacing in the course card view

### DIFF
--- a/clients/core/src/managementConsole/shared/components/CourseCard/CourseCards.tsx
+++ b/clients/core/src/managementConsole/shared/components/CourseCard/CourseCards.tsx
@@ -21,8 +21,8 @@ export const CourseCards = ({ courses }: CourseCardsProps) => {
   }, [courses, query])
 
   return (
-    <div className='container mx-auto px-4 py-8'>
-      <div className='relative mb-8 max-w-md'>
+    <div className='flex flex-col gap-6'>
+      <div className='relative max-w-md'>
         <Search className='pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
         <Input
           type='search'

--- a/clients/core/src/managementConsole/shared/components/CourseCard/CourseCards.tsx
+++ b/clients/core/src/managementConsole/shared/components/CourseCard/CourseCards.tsx
@@ -30,7 +30,7 @@ export const CourseCards = ({ courses }: CourseCardsProps) => {
           placeholder='Search courses...'
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          className='pl-9'
+          className='appearance-none pl-9'
         />
       </div>
 


### PR DESCRIPTION
## Summary

Fixes the course search field in the card view: the magnifying glass no longer sits on top of the placeholder, and the field now follows the page header with the same spacing the rest of the page uses.

## Details

- `Input` is rendered with `type='search'`, which Safari draws with the native `-webkit-appearance: searchfield`. That appearance ignores custom horizontal padding, so the `pl-9` that reserves room for the icon had no effect and the placeholder rendered underneath it. Adding `appearance-none` makes the padding apply again. The `type='search'` (and with it the `searchbox` role the e2e suite queries) is kept.
- `CourseCards` wrapped itself in `container mx-auto px-4 py-8`. Its `py-8` stacked on top of the page's own `gap-6`, leaving a wide empty band under the "Courses" heading, and `container mx-auto px-4` kept the card grid narrower than the table view of the same page. Replaced with `flex flex-col gap-6`, matching the pages that render it and the table view next to it.

## Reason / Link to issue

Closes #2084
Closes #2011

## How to Test

1. Open `/management/general` (Courses) and select the card view.
2. The placeholder text starts to the right of the magnifying glass, in Safari as well as Chrome/Firefox.
3. The search field sits directly under the header with the normal page spacing, and the card grid uses the full page width like the table view does.
4. Repeat on the Template Courses and Archived Courses pages, which render the same component.

## PR Checklist

- [ ] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
