### PR TITLE
`Core`: Fix the overlapping search icon and spacing in the course card view

### DIFF
--- a/clients/core/src/managementConsole/shared/components/CourseCard/CourseCards.tsx
+++ b/clients/core/src/managementConsole/shared/components/CourseCard/CourseCards.tsx
@@ -24,13 +24,14 @@ export const CourseCards = ({ courses }: CourseCardsProps) => {
     <div className='container mx-auto px-4 py-8'>
       <div className='relative mb-8 max-w-md'>
         <Search className='pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
+        {/* Remotes ship their own Tailwind build, so an unprefixed pl-9 loses to their .px-3 */}
         <Input
           type='search'
           aria-label='Search courses'
           placeholder='Search courses...'
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          className='pl-9'
+          className='pl-9!'
         />
       </div>
 

--- a/clients/core/src/managementConsole/shared/components/CourseCard/CourseCards.tsx
+++ b/clients/core/src/managementConsole/shared/components/CourseCard/CourseCards.tsx
@@ -21,8 +21,8 @@ export const CourseCards = ({ courses }: CourseCardsProps) => {
   }, [courses, query])
 
   return (
-    <div className='container mx-auto px-4 py-8'>
-      <div className='relative mb-8 max-w-md'>
+    <div className='flex flex-col gap-6'>
+      <div className='relative max-w-md'>
         <Search className='pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
         {/* Remotes ship their own Tailwind build, so an unprefixed pl-9 loses to their .px-3 */}
         <Input


### PR DESCRIPTION
## Summary

Fixes the course search field in the card view: the magnifying glass no longer sits on top of the placeholder, and the field now follows the page header with the same spacing the rest of the page uses.

## Details

**Search icon overlap.** The field reserves room for the icon with `pl-9`, but at runtime the input renders with `padding-left: 12px`, so the placeholder starts underneath the icon.

The cause is stylesheet order across bundles, not the class itself. Core and every remote build their own full Tailwind stylesheet and inject it with `style-loader`, so a remote's `<style>` lands in `<head>` after core's. The remotes do not use `pl-9`, so their copy of `.px-3` (from the shared `Input` base classes) is the last equal-specificity rule for `padding-left` and wins over core's `.pl-9`. Verified against the deployed bundles: `main.*.js` carries `.px-3` at 42279 and `.pl-9` at 44065, while `assessment/main.*.js` carries `.px-3` and no `.pl-9` at all.

Marking the utility important (`pl-9!`) makes the override survive the later stylesheet. This is a targeted fix for the reported field; the ordering problem itself is broader (`AddUserDialog` and `TutorSearchStudents` use the same `pl-10` pattern and are exposed to it) and is tracked separately in #2086.

**Spacing.** `CourseCards` wrapped itself in `container mx-auto px-4 py-8`. Its `py-8` stacked on top of the page's own `gap-6`, leaving a wide empty band under the "Courses" heading, and `container mx-auto px-4` kept the card grid narrower than the table view of the same page. Replaced with `flex flex-col gap-6`, matching the pages that render it and the table view next to it.

## Reason / Link to issue

Closes #2084
Closes #2011

## How to Test

1. Open `/management/general` (Courses) and select the card view.
2. Visit a course phase first so at least one remote is loaded, then go back to Courses. The placeholder text starts to the right of the magnifying glass.
3. The search field sits directly under the header with the normal page spacing, and the card grid uses the full page width like the table view does.
4. Repeat on the Template Courses and Archived Courses pages, which render the same component.

Verified locally by rendering the component's markup against the real core stylesheet with the remote stylesheet injected after it: `padding-left` is `12px` on `main` and `36px` with this change.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [ ] Documentation updated (if relevant)
