### PR TITLE
`Authentication`: Fix the Keycloak realm import failing on a fresh database

### DIFF
--- a/api-stress/README.md
+++ b/api-stress/README.md
@@ -60,9 +60,8 @@ Output lands in `api-stress/reports/<timestamp>/` (`report.md` first).
 
 Host ports are offset by +10000 to avoid collisions: core `18089`, team-alloc
 `18083`, self-team `18084`, assessment `18085`, example `18086`, interview
-`18087`, certificate `18088`, Keycloak `18081`, S3 `18334`. Keycloak is pinned to
-`26.4.7` (the repo's pinned `26.6.3` fails to import the committed realm on a fresh
-DB - see report finding). Sentry is disabled. Teardown:
+`18087`, certificate `18088`, Keycloak `18081`, S3 `18334`. Sentry is disabled.
+Teardown:
 
 ```bash
 docker compose -p prompt-stress down -v

--- a/api-stress/README.md
+++ b/api-stress/README.md
@@ -61,10 +61,13 @@ Output lands in `api-stress/reports/<timestamp>/` (`report.md` first).
 Host ports are offset by +10000 to avoid collisions: core `18089`, team-alloc
 `18083`, self-team `18084`, assessment `18085`, example `18086`, interview
 `18087`, certificate `18088`, Keycloak `18081`, S3 `18334`. Sentry is disabled.
-Teardown:
+Teardown takes the same file set, because `-v` only removes volumes the loaded files
+declare and the override is what renames them:
 
 ```bash
-docker compose -p prompt-stress down -v
+docker compose --env-file api-stress/stress.env \
+  -f docker-compose.yml -f api-stress/docker-compose.stress.yml \
+  -p prompt-stress down -v
 ```
 
 ## Extending

--- a/api-stress/docker-compose.stress.yml
+++ b/api-stress/docker-compose.stress.yml
@@ -47,12 +47,8 @@ services:
     volumes: !override ["stress_pg_keycloak:/var/lib/postgresql/data"]
 
   # ---- keycloak (published on 18081; issuer port must match) ----
-  # NOTE: pinned to 26.4.7 because the repo's pinned 26.6.3 fails to import the
-  # committed keycloakConfig.json on a fresh DB ("Duplicate resource error" /
-  # UK_J3RWUVD56ONTGSUHOGM184WW2). Recorded as a setup finding in the report.
   keycloak:
     container_name: stress-keycloak
-    image: quay.io/keycloak/keycloak:26.4.7
     ports: !override ["18081:8080", "19000:9000"]
     environment:
       KC_HOSTNAME_PORT: "18081"

--- a/api-stress/stress/cli.py
+++ b/api-stress/stress/cli.py
@@ -269,7 +269,7 @@ def main(argv: list[str] | None = None) -> int:
         "started": timestamp,
         "intensity": args.intensity,
         "scenarios": " ".join(scenarios),
-        "stack": "prompt-stress (isolated, keycloak 26.4.7)",
+        "stack": "prompt-stress (isolated)",
         "catalog_count": catalog_count(),
         "core_url": CORE_URL,
     }

--- a/docs/contributor/guide/api-stress-testing.md
+++ b/docs/contributor/guide/api-stress-testing.md
@@ -81,8 +81,10 @@ api-stress/run.sh --smoke-only       # quick reachability + latency baseline
 api-stress/run.sh --no-exhaustion    # skip the host-stressing lane (good for repeats)
 api-stress/run.sh --intensity brutal # all-out
 
-# 4. teardown when done
-docker compose -p prompt-stress down -v
+# 4. teardown when done (same file set: -v only removes volumes the files declare)
+docker compose --env-file api-stress/stress.env \
+  -f docker-compose.yml -f api-stress/docker-compose.stress.yml \
+  -p prompt-stress down -v
 ```
 
 Output lands in `api-stress/reports/<timestamp>/` (gitignored). Open `report.md` first.
@@ -132,8 +134,16 @@ These are deliberate design choices worth preserving when you extend the suite:
 ## Troubleshooting
 
 - **All requests 401 right after a teardown:** you wiped the keycloak volume, so the
-  realm is gone. Recreate it with
-  `docker compose -p prompt-stress up -d keycloak-db keycloak`.
+  realm is gone. Recreate it with the file set from step 2 - the override is what
+  publishes Keycloak on `18081`, pins the issuer port and gives `keycloak-db` its own
+  volume, so a bare `docker compose -p prompt-stress up` brings it back on the default
+  port with the dev stack's `keycloak_postgres_data` bind-mounted into it:
+
+  ```bash
+  docker compose --env-file api-stress/stress.env \
+    -f docker-compose.yml -f api-stress/docker-compose.stress.yml \
+    -p prompt-stress up -d keycloak-db keycloak
+  ```
 - **Everything 401 mid-run / IDOR count drops to 0:** tokens expired. `run.sh` raises
   the realm `accessTokenLifespan` to 1h at preflight and re-mints before fuzzing; if
   you call the Python tools directly, mint fresh tokens first (`lib/auth.py`).

--- a/docs/contributor/guide/api-stress-testing.md
+++ b/docs/contributor/guide/api-stress-testing.md
@@ -131,10 +131,8 @@ These are deliberate design choices worth preserving when you extend the suite:
 
 ## Troubleshooting
 
-- **Keycloak crash-loops on import** ("Duplicate resource error" /
-  `UK_J3RWUVD56ONTGSUHOGM184WW2`): the repo pins Keycloak `26.6.3`, which fails to
-  import the committed realm on a fresh DB. The override pins **`26.4.7`**, which
-  imports cleanly. If you wiped the keycloak volume, recreate it:
+- **All requests 401 right after a teardown:** you wiped the keycloak volume, so the
+  realm is gone. Recreate it with
   `docker compose -p prompt-stress up -d keycloak-db keycloak`.
 - **Everything 401 mid-run / IDOR count drops to 0:** tokens expired. `run.sh` raises
   the realm `accessTokenLifespan` to 1h at preflight and re-mints before fuzzing; if

--- a/docs/contributor/keycloak-dev.md
+++ b/docs/contributor/keycloak-dev.md
@@ -1,7 +1,7 @@
 # Keycloak Local Development Guide
 
 ## 1. Local Setup (Step-by-Step)
-1. **Launch Containers:** Use `docker-compose up -d keycloak keycloak-db`. 
+1. **Launch Containers:** Use `docker-compose up -d keycloak keycloak-db`.
 2. **Auto-Import:** The system is configured to import `keycloakConfig.json` automatically on startup.
 3. **Verify:** Access the UI at `http://localhost:8081`.
 
@@ -21,6 +21,7 @@ The following accounts are included in `keycloakConfig.json` to facilitate testi
 ## 3. Modifying Users and Roles
 - **Adding Users:** Go to `Users` -> `Add user`. Required fields: Username, Email, First/Last Name.
 - **Assigning Roles:** Go to `Users` -> pick user -> go to `Role Mapping` tab and `Assign role`.
+- **Editing `keycloakConfig.json` by hand:** every client role a user or group references must also be declared under `roles.client`. Keycloak creates undeclared roles implicitly, and since 26.6 two users referencing the same undeclared role abort the import with a duplicate-resource error on a fresh database.
 
 ## 4. Manual Client Mapper Configuration
 If you need to manually add mappers for `prompt-server`:

--- a/keycloakConfig.json
+++ b/keycloakConfig.json
@@ -331,6 +331,30 @@
             "clientRole": true,
             "containerId": "a584ca61-fa83-4e95-98b6-c5f3157ae4b4",
             "attributes": {}
+          },
+          {
+            "name": "PROMPT_Course_Editor",
+            "description": "",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "a584ca61-fa83-4e95-98b6-c5f3157ae4b4",
+            "attributes": {}
+          },
+          {
+            "name": "PROMPT_Course_Lecturer",
+            "description": "",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "a584ca61-fa83-4e95-98b6-c5f3157ae4b4",
+            "attributes": {}
+          },
+          {
+            "name": "PROMPT_Student",
+            "description": "",
+            "composite": false,
+            "clientRole": true,
+            "containerId": "a584ca61-fa83-4e95-98b6-c5f3157ae4b4",
+            "attributes": {}
           }
         ],
         "account": [
@@ -615,7 +639,7 @@
         "createdTimestamp": 1737552859689,
         "emailVerified": true,
         "enabled": true,
-        "requiredActions": ["webauthn-register-passwordless"], 
+        "requiredActions": ["webauthn-register-passwordless"],
         "credentials": [{ "type": "password", "value": "student-passkey", "temporary": false }],
         "attributes": {
           "university_login": ["no43tum"],


### PR DESCRIPTION
## Summary

`keycloakConfig.json` could not be imported by the pinned Keycloak `26.6.3` on a fresh database, so
`make db` crash-looped the container. The realm export was missing three client-role declarations;
declaring them makes the import work again.

## Details

The export only declared `PROMPT_Admin` and `PROMPT_Lecturer` under `roles.client["prompt-server"]`,
while the seeded users reference `PROMPT_Student`, `PROMPT_Course_Lecturer` and
`PROMPT_Course_Editor` as well. Keycloak creates such undeclared roles implicitly while importing the
users. On `26.6.3` the two users that both reference `PROMPT_Student` each trigger that implicit
creation and the second insert violates the unique constraint on `KEYCLOAK_ROLE`, aborting the whole
import:

```
ERROR: Duplicate resource error
ERROR: ... duplicate key value violates unique constraint "UK_J3RWUVD56ONTGSUHOGM184WW2-2"
```

- `keycloakConfig.json`: declare all five `prompt-server` client roles, matching what
  `e2e/keycloak/realm.json` already does. The pre-commit hygiene hooks also fixed a stray trailing
  space and the missing final newline in the same file.
- `api-stress/`: drop the `26.4.7` workaround pin so the isolated stress stack follows the repo-wide
  image pin again, and adjust the README, the guide and the run metadata accordingly.
- `docs/contributor/keycloak-dev.md`: note that hand-edited realm roles must be declared explicitly.

No changes were needed for existing local setups: the import strategy is `IGNORE_EXISTING`, and
volumes that already hold the realm keep the implicitly created roles.

## Reason / Link to issue

Closes #1746.

## How to Test

1. `rm -rf keycloak_postgres_data` (or `docker compose down -v`) to force a fresh Keycloak database.
2. `make db`
3. `docker logs prompt-keycloak` shows `Realm 'prompt' imported` and the server starting, with no
   `Duplicate resource error` and no restart loop.
4. `curl -s -X POST http://localhost:8081/realms/prompt/protocol/openid-connect/token -d client_id=prompt-client -d username=student -d password=student -d grant_type=password`
   returns a token whose `resource_access.prompt-server.roles` contains `PROMPT_Student`.

Verified locally against `26.6.3` on both a fresh Postgres volume (via `docker compose`) and the
in-container dev database; all six seeded users resolve to exactly the roles listed in
`docs/contributor/keycloak-dev.md`.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added additional client roles for course editors, lecturers, and students in the Keycloak configuration.

- **Documentation**
  - Updated Keycloak setup guidance with client-role import requirements.
  - Revised API stress-testing troubleshooting to recommend recreating the realm after clearing its volume.
  - Simplified stress-stack setup and removed outdated version-specific guidance.

- **Improvements**
  - Stress-test run metadata now uses a simplified stack label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->