### PR TITLE
`Testing`: Verify changes in a real host browser

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,43 +1,97 @@
 ---
 name: verify
-description: Run PROMPT 2.0 and observe a change in the real UI or API. Boots the seeded e2e stack (core client + server + Keycloak + Postgres + SeaweedFS) without the Playwright suite and drives it from inside the compose network. Use when verifying a client or core-server change at its surface rather than through tests.
+description: Run PROMPT 2.0 and observe a change in a real browser. Boots the seeded e2e stack (core client + server + Keycloak + Postgres + SeaweedFS) in host-browser mode and drives it with the Playwright MCP browser. Use when verifying a client or core-server change at its surface rather than through tests.
 ---
 
-# Verify a change against a running PROMPT stack
+# Verify a change in a real browser
 
-The `docker-compose.e2e.yml` stack is the fastest handle: it boots the core client, the
-core server, every phase service, Keycloak with an imported realm, and a fully seeded
-database (`e2e/seed/e2e_seed.sql`) on ports that coexist with a dev stack — client 4000,
-core API 18090, Keycloak 18081.
+The `docker-compose.e2e.yml` stack is the fastest handle: core client, core server, every
+phase service, Keycloak with an imported realm, and a fully seeded database
+(`e2e/seed/e2e_seed.sql`) on ports that coexist with a dev stack — client 4000, core API
+18090, Keycloak 18081, Mailpit 18025.
 
-## Boot the app without running tests
+`e2e/docker-compose.browser.yml` overlays it for **host-browser mode**, and
+`make verify-up` boots that combination. Drive it with the **Playwright MCP** browser
+(`mcp__playwright__*`), the same way changes are verified in FASTLANE.
 
-The Makefile exports `.env` / `.env.dev`, whose host-mode overrides outrank
-`--env-file e2e/.env.e2e`, so unset those keys (this is what `make test-e2e-*` does):
+## 1. Boot the stack
 
 ```bash
-env -u DB_CORE_HOST -u DB_CORE_PORT -u DB_CORE_USER -u DB_CORE_PASSWORD -u DB_CORE_NAME \
-    -u KEYCLOAK_HOST -u CORE_HOST -u SERVER_ADDRESS \
-  docker compose -f docker-compose.e2e.yml --env-file e2e/.env.e2e up -d client-core server-core
+make verify-up               # add SKIP_BUILD=1 to reuse images already built
 ```
 
-`depends_on` pulls in the databases, Keycloak and SeaweedFS. A cold build is ~10 min;
-afterwards startup is under a minute. Readiness:
+A cold build is ~10 min; afterwards startup is under a minute. Readiness:
 
 ```bash
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:18090/api/hello   # core API
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:4000              # core client
 ```
 
-Tear down with `make test-e2e-down` (removes volumes, so the seed is fresh next boot).
+Tear down with `make verify-down` (removes volumes, so the seed is fresh next boot).
 
-## Drive it from inside the compose network, not from the host
+## 2. Drive the browser
 
-The client's runtime config points the browser at `http://keycloak:8080`, a name only
-Docker DNS resolves — a host browser dies on `ERR_NAME_NOT_RESOLVED` at the login
-redirect, and a Keycloak token minted via `localhost:18081` is rejected by the server as
-`{"error":"Invalid token"}` (issuer mismatch). Run driver scripts in the `e2e-runner`
-container instead: it sits on the network and ships Playwright plus Chromium.
+Navigate to `http://localhost:4000/management`, log in, and interact. Seeded accounts are
+in `e2e/src/data/roles.ts` — **username equals password** (`lecturer`, `admin`, `student`,
+…). Seeded courses, phases and participants are in `e2e/src/data/constants.ts`.
+
+The login form is Keycloak's own page; log in the way the suite does
+(`e2e/src/pages/LoginPage.ts`): fill `#username` / `#password`, click `#kc-login`, then
+wait for the app shell. Sequence with the MCP tools:
+
+1. `browser_navigate` → `http://localhost:4000/management`
+2. `browser_snapshot` to get refs for the Keycloak fields
+3. `browser_type` into `#username` / `#password`, `browser_click` `#kc-login`
+4. `browser_snapshot` again once redirected back, then click through to the change
+5. `browser_take_screenshot` for the evidence, `browser_console_messages` for errors
+
+Snapshots and console logs land in the gitignored `.playwright-mcp/` on their own, but
+`browser_take_screenshot` resolves its `filename` against the repo root — pass an explicit
+`.playwright-mcp/<name>.png` or the image lands in the working tree, where only a
+`git status` catches it. Always report what you observed, and show a screenshot of the
+changed surface.
+
+## 3. Exercising real write paths
+
+A lecturer token drives any core API directly from the host, which beats hand-editing the
+seed when you need a state the fixtures don't have:
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:18081/realms/prompt/protocol/openid-connect/token \
+  -d client_id=prompt-client -d username=lecturer -d password=lecturer \
+  -d grant_type=password | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:18090/api/courses | head -c 400
+```
+
+## Why host-browser mode exists
+
+The base stack addresses everything by compose service name (`http://client-core`,
+`http://keycloak:8080`), because the containerized runner's Chromium resolves those via
+Docker DNS. A host browser cannot: it dies on `ERR_NAME_NOT_RESOLVED` at the login
+redirect, and a token minted via `localhost:18081` against the unmodified stack is
+rejected as `{"error":"Invalid token"}` (issuer mismatch).
+
+The overlay fixes both ends so there is exactly one issuer,
+`http://localhost:18081/realms/prompt`:
+
+- `client-core` gets `CORE_HOST=http://localhost:18090` and
+  `KEYCLOAK_HOST=http://localhost:18081` in its `env.js` (generated by the container
+  entrypoint at start, so no rebuild is needed for an env change).
+- `server-core` gets `CORE_HOST=http://localhost:4000` (the CORS allow-list origin) and
+  the same `KEYCLOAK_HOST`.
+- Every token-validating server gets `localhost:host-gateway`, so `localhost:18081`
+  resolves to the published Keycloak port from inside its container.
+- `seaweedfs-s3` is published on 18333 and `S3_PUBLIC_ENDPOINT` points there, so
+  presigned upload/download URLs handed to the browser resolve on the host.
+
+The e2e realm already whitelists `http://localhost:4000/*` as a redirect URI and web
+origin, so no realm edit is needed.
+
+## Fallback: drive from inside the compose network
+
+Only needed when you must reproduce the suite's exact DNS-name environment (for example
+debugging a failing spec's own navigation). Run a throwaway driver in the `e2e-runner`
+container, which sits on the network and ships Playwright plus Chromium:
 
 ```bash
 env -u DB_CORE_HOST -u DB_CORE_PORT -u DB_CORE_USER -u DB_CORE_PASSWORD -u DB_CORE_NAME \
@@ -52,36 +106,21 @@ core API and `http://keycloak:8080` for tokens. Screenshots written to
 `/work/test-results` land in `e2e/test-results/` on the host. Delete the driver script
 from the repo when done — `e2e/` is checked in.
 
-Log in the way the suite does (`e2e/src/pages/LoginPage.ts`): go to `/management`, fill
-`#username` / `#password`, click `#kc-login`, then wait for the `jwt_token` localStorage
-key. Seeded accounts are in `e2e/src/data/roles.ts` — username equals password
-(`lecturer`, `admin`, `student`, …). Seeded courses, phases and participants are in
-`e2e/src/data/constants.ts`.
-
-## Exercising real write paths
-
-A lecturer token from the container drives any core API directly, which beats hand-editing
-the seed when you need a state the fixtures don't have:
-
-```js
-const body = new URLSearchParams({ client_id: 'prompt-client', username: 'lecturer',
-  password: 'lecturer', grant_type: 'password' })
-const { access_token } = await (await fetch(
-  'http://keycloak:8080/realms/prompt/protocol/openid-connect/token',
-  { method: 'POST', body })).json()
-```
-
 ## Gotchas
 
 - `/management/**` mounts Keycloak with `onLoad: 'login-required'`; the public landing
   page does not, so always enter through a management route.
-- The console logs a `[prompt-shared-state] Missing or invalid env keys` warning and
-  404s for optional phase assets on every page — pre-existing noise, not your change.
+- Every page logs a `[prompt-shared-state] Missing or invalid env keys` warning and a pair
+  of `Unexpected token '<'` errors (404 HTML served where an optional phase asset was
+  expected). Offline you also get `ERR_NAME_NOT_RESOLVED` for the `gravatar.com` avatar.
+  All pre-existing noise, not your change.
 - The seed is a `pg_dump` file loaded by `initdb` with `ON_ERROR_STOP`: one duplicate key
   aborts it and the whole stack fails to boot with `container prompt-e2e-db exited (3)`.
   Validate a seed edit on its own before a full run:
   `docker run --rm -e POSTGRES_PASSWORD=x -e POSTGRES_DB=prompt \
    -v "$PWD/e2e/seed/e2e_seed.sql:/docker-entrypoint-initdb.d/e2e_seed.sql:ro" postgres:15.18-alpine`
-- Reusing images with `SKIP_BUILD=1` keeps the *baked-in* copy of `e2e/src` and
-  `e2e/tests`; the seed is a bind mount and updates without a rebuild. Edited constants
-  therefore need a rebuild, or the browser navigates to stale ids.
+- `SKIP_BUILD=1` keeps the *baked-in* copy of `e2e/src` and `e2e/tests` in the runner
+  image; the seed is a bind mount and updates without a rebuild. A client or server code
+  change always needs the build.
+- Both stacks share container names, so run one at a time: `make verify-down` before
+  `make test-e2e-shard`, and vice versa.

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ CLAUDE.local.md
 # Local Tooling (not shared)
 # =============================================================================
 justfile
+
+# Playwright MCP scratch output (screenshots, console logs) from `verify`.
+.playwright-mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,10 @@ make db
 # Stop database and Keycloak
 make db-down
 
+# Boot the seeded stack for browser verification (see the `verify` skill)
+make verify-up
+make verify-down
+
 # Run linting
 make lint
 
@@ -120,8 +124,8 @@ Agent configuration is shared with the team and split by purpose:
 - **Skills** — repeatable procedures in `.agents/skills/` (canonical source), symlinked into
   `.claude/skills/` via `make setup-skills`.
   - Repo-specific: `new-course-phase`, `sqlc-migration`, `add-shared-ui-component`,
-    `module-federation-remote`, `keycloak-local-setup`, `open-pr`, `address-pr-comments`,
-    `github-release-creation`.
+    `module-federation-remote`, `keycloak-local-setup`, `verify`, `open-pr`,
+    `address-pr-comments`, `github-release-creation`.
   - Reference patterns (vendored from ECC, MIT): `golang-patterns`, `postgres-patterns`,
     `react-performance`, `docker-patterns`.
 - **Subagents** — focused reviewers in `.claude/agents/`: `go-service-reviewer`,
@@ -141,6 +145,10 @@ phases: see the external-phase section of the guide and `template-repository/`.
 Run `make lint` and `make test` before completing a change. Go tests use `testcontainers-go`;
 end-to-end tests use Playwright and are documented in `e2e/README.md`. Details:
 `.claude/rules/common/testing.md`.
+
+To observe a change in a real browser rather than through tests, use the `verify` skill:
+`make verify-up` boots the same seeded stack in host-browser mode (client
+<http://localhost:4000>), which is then driven with the Playwright MCP browser.
 
 ## Definition of Done
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 	test-team-allocation test-self-team-allocation test-example \
 	test-certificate test-presentation \
 	test-e2e test-e2e-shard test-e2e-ui test-e2e-down \
+	verify-up verify-down \
 	sqlc sqlc-core sqlc-assessment sqlc-interview \
 	sqlc-team-allocation sqlc-self-team-allocation sqlc-example \
 	sqlc-certificate sqlc-presentation \
@@ -193,6 +194,28 @@ test-e2e-ui: ## Interactive Playwright UI in Docker - then open http://127.0.0.1
 		-v "$(CURDIR)/e2e/test-results:/work/test-results" \
 		e2e-runner npx playwright test --ui-host=0.0.0.0 --ui-port=8123; \
 		$(E2E_COMPOSE) down -v
+
+# ─── Browser Verification ─────────────────────────────────────────────────────
+
+# Same seeded stack as the e2e suite, overlaid so the client, Keycloak and the
+# core API are reachable as localhost:<published port>. That lets a browser on
+# the host complete the login redirect and mint a token the servers accept.
+# Driven by the `verify` skill.
+VERIFY_COMPOSE = docker compose -f docker-compose.e2e.yml -f e2e/docker-compose.browser.yml --env-file e2e/.env.e2e
+
+verify-up: ## Boot the seeded stack for host-browser verification (SKIP_BUILD=1 reuses existing images)
+	unset $(E2E_ENV_KEYS); \
+		$(if $(SKIP_BUILD),true,$(VERIFY_COMPOSE) build); \
+		$(VERIFY_COMPOSE) up -d client-core server-core
+	@echo ""
+	@echo "client    http://localhost:4000/management"
+	@echo "core API  http://localhost:18090"
+	@echo "keycloak  http://localhost:18081"
+	@echo "mailpit   http://localhost:18025"
+	@echo "logins    username == password (lecturer, admin, student, ...)"
+
+verify-down: ## Tear down the host-browser stack and remove volumes
+	unset $(E2E_ENV_KEYS); $(VERIFY_COMPOSE) down -v
 
 # ─── Code Generation ──────────────────────────────────────────────────────────
 

--- a/e2e/docker-compose.browser.yml
+++ b/e2e/docker-compose.browser.yml
@@ -1,0 +1,57 @@
+# ============================================================================
+# Host-browser overlay for the e2e stack (docker-compose.e2e.yml).
+#
+# The base stack addresses everything by compose service name, because the
+# containerized Playwright runner's Chromium resolves those via Docker DNS. A
+# browser on the *host* cannot: it dies on ERR_NAME_NOT_RESOLVED at the login
+# redirect, and a token minted via localhost:18081 is rejected by the servers
+# as an issuer mismatch.
+#
+# This overlay flips the browser-facing URLs to the published host ports and
+# points every token-validating server at the same localhost Keycloak (via
+# localhost:host-gateway), so host browser and servers agree on one issuer:
+# http://localhost:18081/realms/prompt.
+#
+# Run:   make verify-up   /   make verify-down     (see the `verify` skill)
+# ============================================================================
+
+# Every phase server validates tokens and CORS-checks the browser origin, so it
+# needs the same localhost view of Keycloak and the client as the core server.
+x-host-phase-server: &host-phase-server
+  extra_hosts:
+    - "localhost:host-gateway"
+  environment:
+    - KEYCLOAK_HOST=http://localhost:18081
+    - CORE_HOST=http://localhost:4000
+    - S3_PUBLIC_ENDPOINT=http://localhost:18333
+
+services:
+  server-core:
+    extra_hosts:
+      - "localhost:host-gateway"
+    environment:
+      # CORS allow-list entry for the browser origin, and the base URL in mails.
+      - CORE_HOST=http://localhost:4000
+      - KEYCLOAK_HOST=http://localhost:18081
+      # Presigned upload/download URLs are handed to the browser, so they must
+      # resolve on the host. Server-side S3 calls keep using S3_ENDPOINT.
+      - S3_PUBLIC_ENDPOINT=http://localhost:18333
+
+  client-core:
+    environment:
+      # The client's CORE_HOST is the API base written into env.js.
+      - CORE_HOST=http://localhost:18090
+      - KEYCLOAK_HOST=http://localhost:18081
+
+  server-self-team-allocation: *host-phase-server
+  server-example: *host-phase-server
+  server-assessment: *host-phase-server
+  server-interview: *host-phase-server
+  server-certificate: *host-phase-server
+  server-presentation: *host-phase-server
+  server-team-allocation: *host-phase-server
+
+  seaweedfs-s3:
+    # Not published in the base stack; the host browser needs it for presigned URLs.
+    ports:
+      - "18333:8333"


### PR DESCRIPTION
## Summary

Adds a host-browser mode to the seeded e2e stack so a change can be observed in a real browser, and rewrites the `verify` skill to drive it with the Playwright MCP browser.

## Details

The e2e stack addresses every service by compose name (`http://client-core`, `http://keycloak:8080`), because the containerized Playwright runner's Chromium resolves those via Docker DNS. A browser on the host cannot: it fails with `ERR_NAME_NOT_RESOLVED` at the login redirect, and a token minted via `localhost:18081` against the unmodified stack is rejected by the servers as an issuer mismatch. The old `verify` skill documented this as a dead end and worked around it with a throwaway driver script inside the `e2e-runner` container.

- **`e2e/docker-compose.browser.yml`** — overlay on `docker-compose.e2e.yml` that makes host browser and servers agree on one issuer, `http://localhost:18081/realms/prompt`:
  - `client-core` gets `CORE_HOST=http://localhost:18090` and `KEYCLOAK_HOST=http://localhost:18081` in its `env.js` (generated by the container entrypoint, so no rebuild is needed).
  - `server-core` gets `CORE_HOST=http://localhost:4000`, the CORS allow-list origin.
  - Every token-validating server gets `localhost:host-gateway`, so `localhost:18081` resolves to the published Keycloak port from inside its container.
  - `seaweedfs-s3` is published on 18333 with `S3_PUBLIC_ENDPOINT` pointing there, so presigned URLs handed to the browser resolve on the host.

  The e2e realm already whitelists `http://localhost:4000/*` as a redirect URI and web origin, so no realm change was needed.
- **`Makefile`** — `make verify-up` (with `SKIP_BUILD=1`) and `make verify-down`. Both reuse the existing `E2E_ENV_KEYS` unset so `e2e/.env.e2e` stays authoritative.
- **`.mcp.json`** — registers the Playwright MCP server. Enabling it per-developer stays in the gitignored `.claude/settings.local.json`, so a first launch after pulling this prompts for approval as usual.
- **`.agents/skills/verify/SKILL.md`** — rewritten around the MCP browser. The container-driver approach stays documented as a fallback for reproducing the suite's DNS-name environment.
- **`AGENTS.md`, `.gitignore`** — document the new targets; ignore the `.playwright-mcp/` scratch output.

CI is untouched: the new overlay is opt-in via the `verify-*` targets, and `make test-e2e-shard` still runs the base compose file alone.

## Reason / Link to issue

Verifying a client or core-server change at its surface meant either writing a throwaway Playwright script into the checked-in `e2e/` directory or relying on tests. Driving the real UI is now a first-class step, matching how the browser is used for verification in our other repos.

## How to Test

1. `SKIP_BUILD=1 make verify-up` (drop `SKIP_BUILD` for a cold build, ~10 min).
2. Confirm readiness: `curl -s -o /dev/null -w '%{http_code}\n' http://localhost:18090/api/hello` and the same against `http://localhost:4000`.
3. Open `http://localhost:4000/management` in a browser and log in as `lecturer` / `lecturer`. The redirect must go to `http://localhost:18081/...` with `redirect_uri=http://localhost:4000/management`.
4. Click into a phase (e.g. Assessment) and confirm the micro-frontend renders — this exercises the remote fetch, the phase server's token validation, and the `prompt-sdk` round-trip to core.
5. `make verify-down`.

Verified on this branch: login succeeded with issuer `http://localhost:18081/realms/prompt`, the core API accepted the token, the CORS preflight returned `Access-Control-Allow-Origin: http://localhost:4000`, and the assessment, interview, certificate and self-team-allocation phase APIs all returned 200 with a token and 401 without.

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [ ] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added browser-based verification for the seeded application stack using Playwright.
  - Added streamlined commands to start and stop the verification environment.
  - Added host-accessible service endpoints, including support for browser-based file interactions.

- **Documentation**
  - Expanded verification guidance with login, screenshots, console inspection, API testing, environment overrides, and troubleshooting notes.
  - Documented the browser verification workflow and fallback testing approach.

- **Chores**
  - Excluded local Playwright tooling output from version control.
  - Added configuration for the Playwright browser automation server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->