### PR TITLE
`Testing`: Add a Vitest runner and seed it with the pure assessment modules

### DIFF
--- a/.claude/rules/common/testing.md
+++ b/.claude/rules/common/testing.md
@@ -1,6 +1,11 @@
 # Testing (all code)
 
 - Run `make lint` and `make test` before considering a change done.
+- **Clients:** Vitest at the `clients/` workspace root (`make test-clients`, or `yarn test` from
+  `clients/`; `yarn vitest run <workspace>` for one workspace). Tests are colocated as
+  `*.test.ts(x)` next to the module they cover, run in a `node` environment, and import
+  `describe`/`it`/`expect` from `vitest` explicitly. Keep them on pure modules: anything needing a
+  browser belongs in the Playwright suite.
 - **Go:** `cd servers/<service> && go test ./...`. Tests use `testcontainers-go` for DB isolation;
   seed data from `database_dumps/*.sql`; pattern `*_test.go` with `testutils.SetupTestDB()`.
 - **End-to-end:** Playwright, in `e2e/`, one shard at a time. Run `make test-e2e-shard SHARD=<name>`

--- a/.github/workflows/quality-clients.yml
+++ b/.github/workflows/quality-clients.yml
@@ -43,5 +43,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-node
+      - run: yarn install
       - name: Run client unit tests
         run: yarn test

--- a/.github/workflows/quality-clients.yml
+++ b/.github/workflows/quality-clients.yml
@@ -34,3 +34,14 @@ jobs:
         run: yarn biome check "${{ matrix.module }}" shared
       - name: Build component ${{ matrix.module }}
         run: yarn --cwd "${{ matrix.module }}" build
+
+  test-client:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./clients
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-node
+      - name: Run client unit tests
+        run: yarn test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,11 @@ make db-down
 # Run linting
 make lint
 
-# Run tests
+# Run tests (client unit tests + every server suite)
 make test
+
+# Run only the client unit tests
+make test-clients
 
 # Regenerate sqlc code for every service (or make sqlc-<service>)
 make sqlc
@@ -138,9 +141,9 @@ phases: see the external-phase section of the guide and `template-repository/`.
 
 ## Testing
 
-Run `make lint` and `make test` before completing a change. Go tests use `testcontainers-go`;
-end-to-end tests use Playwright and are documented in `e2e/README.md`. Details:
-`.claude/rules/common/testing.md`.
+Run `make lint` and `make test` before completing a change. Client unit tests run on Vitest from
+`clients/` (`make test-clients`); Go tests use `testcontainers-go`; end-to-end tests use Playwright
+and are documented in `e2e/README.md`. Details: `.claude/rules/common/testing.md`.
 
 ## Definition of Done
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 	server-team-allocation server-self-team-allocation server-example \
 	server-certificate server-presentation \
 	lint lint-clients lint-servers \
-	test test-core test-assessment test-interview \
+	test test-clients test-core test-assessment test-interview \
 	test-team-allocation test-self-team-allocation test-example \
 	test-certificate test-presentation \
 	test-e2e test-e2e-shard test-e2e-ui test-e2e-down \
@@ -115,7 +115,10 @@ lint-servers: ## Run go vet on all servers
 
 # ─── Testing ───────────────────────────────────────────────────────────────────
 
-test: test-core test-assessment test-interview test-team-allocation test-self-team-allocation test-example test-certificate test-presentation ## Run all server tests
+test: test-clients test-core test-assessment test-interview test-team-allocation test-self-team-allocation test-example test-certificate test-presentation ## Run all client and server tests
+
+test-clients: ## Run all client unit tests
+	cd clients && yarn install && yarn test
 
 test-core: ## Run core server tests
 	cd servers/core && go test ./...

--- a/clients/assessment_component/src/assessment/pages/SettingsPage/components/GradeExportCard/utils/campusCsvEncoding.test.ts
+++ b/clients/assessment_component/src/assessment/pages/SettingsPage/components/GradeExportCard/utils/campusCsvEncoding.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeCsvFile, encodeCsvText, getCsvMimeType } from './campusCsvEncoding'
+
+const toBuffer = (bytes: number[]): ArrayBuffer => new Uint8Array(bytes).buffer
+
+const UTF8_BOM = [0xef, 0xbb, 0xbf]
+const WINDOWS_1252_MUELLER = [0x4d, 0xfc, 0x6c, 0x6c, 0x65, 0x72]
+
+describe('decodeCsvFile', () => {
+  it('rejects UTF-16 rather than corrupting it', () => {
+    expect(() => decodeCsvFile(toBuffer([0xff, 0xfe, 0x4d, 0x00]))).toThrow(/UTF-16/)
+    expect(() => decodeCsvFile(toBuffer([0xfe, 0xff, 0x00, 0x4d]))).toThrow(/UTF-16/)
+  })
+
+  it('strips a UTF-8 BOM and remembers it was there', () => {
+    const bytes = [...UTF8_BOM, ...new TextEncoder().encode('Müller')]
+
+    expect(decodeCsvFile(toBuffer(bytes))).toEqual({ text: 'Müller', encoding: 'utf-8-bom' })
+  })
+
+  it('reads a plain UTF-8 file', () => {
+    const bytes = [...new TextEncoder().encode('Müller')]
+
+    expect(decodeCsvFile(toBuffer(bytes))).toEqual({ text: 'Müller', encoding: 'utf-8' })
+  })
+
+  it('falls back to Windows-1252 for bytes that are not valid UTF-8', () => {
+    expect(decodeCsvFile(toBuffer(WINDOWS_1252_MUELLER))).toEqual({
+      text: 'Müller',
+      encoding: 'windows-1252',
+    })
+  })
+})
+
+describe('encodeCsvText', () => {
+  it('round trips Windows-1252 umlauts', () => {
+    const encoded = encodeCsvText('Müller', 'windows-1252')
+
+    expect([...encoded]).toEqual(WINDOWS_1252_MUELLER)
+    expect(decodeCsvFile(encoded.buffer)).toEqual({ text: 'Müller', encoding: 'windows-1252' })
+  })
+
+  it('round trips the printable characters Windows-1252 keeps in the C1 range', () => {
+    const encoded = encodeCsvText('€Š™', 'windows-1252')
+
+    expect([...encoded]).toEqual([0x80, 0x8a, 0x99])
+  })
+
+  it('writes an unmappable character as a question mark', () => {
+    expect([...encodeCsvText('中', 'windows-1252')]).toEqual([0x3f])
+  })
+
+  it('round trips UTF-8 without a BOM', () => {
+    const encoded = encodeCsvText('Müller', 'utf-8')
+
+    expect(decodeCsvFile(encoded.buffer)).toEqual({ text: 'Müller', encoding: 'utf-8' })
+  })
+
+  it('round trips UTF-8 with a BOM', () => {
+    const encoded = encodeCsvText('Müller', 'utf-8-bom')
+
+    expect([...encoded.slice(0, 3)]).toEqual(UTF8_BOM)
+    expect(decodeCsvFile(encoded.buffer)).toEqual({ text: 'Müller', encoding: 'utf-8-bom' })
+  })
+})
+
+describe('getCsvMimeType', () => {
+  it('names the charset the file was written in', () => {
+    expect(getCsvMimeType('windows-1252')).toBe('text/csv;charset=windows-1252')
+    expect(getCsvMimeType('utf-8')).toBe('text/csv;charset=utf-8')
+    expect(getCsvMimeType('utf-8-bom')).toBe('text/csv;charset=utf-8')
+  })
+})

--- a/clients/assessment_component/src/assessment/pages/SettingsPage/components/GradeExportCard/utils/fillCampusGrades.test.ts
+++ b/clients/assessment_component/src/assessment/pages/SettingsPage/components/GradeExportCard/utils/fillCampusGrades.test.ts
@@ -1,0 +1,208 @@
+import { PassStatus } from '@tumaet/prompt-shared-state'
+import { describe, expect, it } from 'vitest'
+
+import type { ParsedCampusCsv, StudentGradeEntry } from '../interfaces/campusGradeExport'
+import { fillCampusGrades } from './fillCampusGrades'
+
+const HEADER_ROW = [
+  'REGISTRATION_NUMBER',
+  'FAMILY_NAME_OF_STUDENT',
+  'FIRST_NAME_OF_STUDENT',
+  'GRADE',
+  'DATE_OF_ASSESSMENT',
+]
+
+const COLUMN_INDICES = {
+  registrationNumber: 0,
+  familyName: 1,
+  firstName: 2,
+  grade: 3,
+  dateOfAssessment: 4,
+}
+
+const buildCsv = (
+  dataRows: string[][],
+  columnIndices: Partial<typeof COLUMN_INDICES> = {},
+): ParsedCampusCsv => ({
+  fileName: 'assessment-list.csv',
+  rows: [HEADER_ROW, ...dataRows],
+  columnIndices: { ...COLUMN_INDICES, ...columnIndices },
+  delimiter: ';',
+  newline: '\r\n',
+  hasTrailingNewline: true,
+  encoding: 'windows-1252',
+})
+
+const buildEntry = (overrides: Partial<StudentGradeEntry> = {}): StudentGradeEntry => ({
+  courseParticipationID: 'participation-1',
+  firstName: 'Anna',
+  lastName: 'Müller',
+  matriculationNumber: '03712345',
+  grade: 1.7,
+  completedAt: '2026-02-17T12:00:00Z',
+  passStatus: PassStatus.PASSED,
+  ...overrides,
+})
+
+describe('fillCampusGrades', () => {
+  it('matches a padded registration number against an unpadded one', () => {
+    const csv = buildCsv([['3712345', 'Müller', 'Anna', '', '']])
+
+    const { csv: filledCsv, report } = fillCampusGrades(csv, [buildEntry()])
+
+    expect(filledCsv.rows[1]).toEqual(['3712345', 'Müller', 'Anna', '1.7', '17.02.2026'])
+    expect(report.filled).toEqual([
+      {
+        csvRowNumber: 2,
+        registrationNumber: '3712345',
+        studentName: 'Anna Müller',
+        grade: '1.7',
+        dateOfAssessment: '17.02.2026',
+        matchedBy: 'registrationNumber',
+      },
+    ])
+    expect(report.totalDataRows).toBe(1)
+  })
+
+  it('falls back to a case- and diacritic-insensitive name match', () => {
+    const csv = buildCsv([['', 'MÜLLER', 'ANNA', '', '']])
+
+    const { report } = fillCampusGrades(csv, [buildEntry()])
+
+    expect(report.filled[0].matchedBy).toBe('name')
+    expect(report.nameFallbackCount).toBe(1)
+  })
+
+  it('leaves a row untouched when its registration number matches two students', () => {
+    const csv = buildCsv([['3712345', 'Müller', 'Anna', '', '']])
+    const entries = [
+      buildEntry(),
+      buildEntry({ courseParticipationID: 'participation-2', firstName: 'Anne' }),
+    ]
+
+    const { csv: filledCsv, report } = fillCampusGrades(csv, entries)
+
+    expect(filledCsv.rows[1]).toEqual(['3712345', 'Müller', 'Anna', '', ''])
+    expect(report.filled).toHaveLength(0)
+    expect(report.skipped).toEqual([
+      {
+        csvRowNumber: 2,
+        registrationNumber: '3712345',
+        studentName: 'Anna Müller',
+        reason: 'ambiguous',
+      },
+    ])
+  })
+
+  it('leaves a row untouched when its name matches two students', () => {
+    const csv = buildCsv([['', 'Müller', 'Anna', '', '']])
+    const entries = [
+      buildEntry({ matriculationNumber: '03712345' }),
+      buildEntry({ courseParticipationID: 'participation-2', matriculationNumber: '03799999' }),
+    ]
+
+    const { report } = fillCampusGrades(csv, entries)
+
+    expect(report.skipped[0].reason).toBe('ambiguous')
+  })
+
+  it('grows a short row so the grade and date cells exist', () => {
+    const csv = buildCsv([['3712345', 'Müller', 'Anna']])
+
+    const { csv: filledCsv } = fillCampusGrades(csv, [buildEntry()])
+
+    expect(filledCsv.rows[1]).toEqual(['3712345', 'Müller', 'Anna', '1.7', '17.02.2026'])
+  })
+
+  it('does not mutate the rows it was given', () => {
+    const csv = buildCsv([['3712345', 'Müller', 'Anna', '', '']])
+    const originalRow = [...csv.rows[1]]
+
+    fillCampusGrades(csv, [buildEntry()])
+
+    expect(csv.rows[1]).toEqual(originalRow)
+  })
+
+  it('reports a replaced grade instead of silently overwriting it', () => {
+    const csv = buildCsv([['3712345', 'Müller', 'Anna', '3.0', '01.01.2026']])
+
+    const { report } = fillCampusGrades(csv, [buildEntry()])
+
+    expect(report.overwrittenCount).toBe(1)
+    expect(report.filled[0].overwrittenGrade).toBe('3.0')
+  })
+
+  it('skips a matched student who has no grade in PROMPT', () => {
+    const csv = buildCsv([['3712345', 'Müller', 'Anna', '', '']])
+
+    const { csv: filledCsv, report } = fillCampusGrades(csv, [buildEntry({ grade: null })])
+
+    expect(filledCsv.rows[1][COLUMN_INDICES.grade]).toBe('')
+    expect(report.skipped[0].reason).toBe('noGradeInPrompt')
+  })
+
+  it('reports a row that matches no student as unmatched', () => {
+    const csv = buildCsv([['9999999', 'Schmidt', 'Bernd', '', '']])
+
+    const { report } = fillCampusGrades(csv, [buildEntry()])
+
+    expect(report.skipped[0].reason).toBe('unmatched')
+  })
+
+  it('reports graded students that no row consumed', () => {
+    const csv = buildCsv([['3712345', 'Müller', 'Anna', '', '']])
+    const missing = buildEntry({
+      courseParticipationID: 'participation-2',
+      firstName: 'Bernd',
+      lastName: 'Schmidt',
+      matriculationNumber: '03799999',
+      grade: 2.3,
+    })
+
+    const { report } = fillCampusGrades(csv, [buildEntry(), missing])
+
+    expect(report.gradedStudentsMissingFromCsv).toEqual([
+      {
+        courseParticipationID: 'participation-2',
+        studentName: 'Bernd Schmidt',
+        matriculationNumber: '03799999',
+        grade: 2.3,
+      },
+    ])
+  })
+
+  it('counts a failed student whose grade is not 5.0', () => {
+    const csv = buildCsv([['3712345', 'Müller', 'Anna', '', '']])
+
+    const { report } = fillCampusGrades(csv, [buildEntry({ passStatus: PassStatus.FAILED })])
+
+    expect(report.passStatusMismatchCount).toBe(1)
+  })
+
+  it('keeps the date format the uploaded file already uses', () => {
+    const csv = buildCsv([
+      ['3799999', 'Schmidt', 'Bernd', '2.0', '2026-01-01'],
+      ['3712345', 'Müller', 'Anna', '', ''],
+    ])
+
+    const { csv: filledCsv } = fillCampusGrades(csv, [buildEntry()])
+
+    expect(filledCsv.rows[2][COLUMN_INDICES.dateOfAssessment]).toBe('2026-02-17')
+  })
+
+  it('ignores blank rows', () => {
+    const csv = buildCsv([[''], ['3712345', 'Müller', 'Anna', '', '']])
+
+    const { report } = fillCampusGrades(csv, [buildEntry()])
+
+    expect(report.totalDataRows).toBe(1)
+  })
+
+  it('does not match by name when the file has no name columns', () => {
+    const csv = buildCsv([['', '', '', '', '']], { familyName: -1, firstName: -1 })
+
+    const { report } = fillCampusGrades(csv, [buildEntry()])
+
+    expect(report.skipped[0].reason).toBe('unmatched')
+  })
+})

--- a/clients/assessment_component/src/assessment/pages/components/diagrams/utils/computeQuartile.test.ts
+++ b/clients/assessment_component/src/assessment/pages/components/diagrams/utils/computeQuartile.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeQuartile } from './computeQuartile'
+
+describe('computeQuartile', () => {
+  it('returns 0 for an empty set', () => {
+    expect(computeQuartile([], 0.5)).toBe(0)
+  })
+
+  it('returns the only value of a single-element set', () => {
+    expect(computeQuartile([4], 0.25)).toBe(4)
+  })
+
+  it('sorts the values before picking a quartile', () => {
+    const values = [9, 1, 7, 3, 5]
+
+    expect(computeQuartile(values, 0.25)).toBe(3)
+    expect(computeQuartile(values, 0.5)).toBe(5)
+    expect(computeQuartile(values, 0.75)).toBe(7)
+  })
+
+  it('interpolates between the two neighbouring values', () => {
+    expect(computeQuartile([1, 2, 3, 4], 0.5)).toBe(2.5)
+    expect(computeQuartile([1, 2, 3, 4], 0.25)).toBe(1.75)
+  })
+
+  it('returns the bounds at the extremes', () => {
+    expect(computeQuartile([1, 2, 3, 4], 0)).toBe(1)
+    expect(computeQuartile([1, 2, 3, 4], 1)).toBe(4)
+  })
+
+  it('does not mutate the values it was given', () => {
+    const values = [9, 1, 7]
+
+    computeQuartile(values, 0.5)
+
+    expect(values).toEqual([9, 1, 7])
+  })
+})

--- a/clients/assessment_component/src/assessment/pages/utils/getAverageScoreLevel.test.ts
+++ b/clients/assessment_component/src/assessment/pages/utils/getAverageScoreLevel.test.ts
@@ -1,0 +1,41 @@
+import { ScoreLevel } from '@tumaet/prompt-shared-state'
+import { describe, expect, it } from 'vitest'
+
+import type { CompetencyScore } from '../../interfaces/competencyScore'
+import { getAverageScoreLevel } from './getAverageScoreLevel'
+
+const buildScore = (scoreLevel: ScoreLevel): CompetencyScore => ({
+  id: `score-${scoreLevel}`,
+  courseParticipationID: 'participation-1',
+  coursePhaseID: 'phase-1',
+  competencyID: 'competency-1',
+  scoreLevel,
+})
+
+describe('getAverageScoreLevel', () => {
+  it('has no average without scores', () => {
+    expect(getAverageScoreLevel([])).toBeUndefined()
+  })
+
+  it('returns the level of a single score', () => {
+    expect(getAverageScoreLevel([buildScore(ScoreLevel.Ok)])).toBe(ScoreLevel.Ok)
+  })
+
+  it('rounds an average down to the better level at the boundary', () => {
+    const scores = [buildScore(ScoreLevel.VeryGood), buildScore(ScoreLevel.Good)]
+
+    expect(getAverageScoreLevel(scores)).toBe(ScoreLevel.VeryGood)
+  })
+
+  it('maps an average between two levels to the better one', () => {
+    const scores = [buildScore(ScoreLevel.Good), buildScore(ScoreLevel.Ok)]
+
+    expect(getAverageScoreLevel(scores)).toBe(ScoreLevel.Good)
+  })
+
+  it('maps the worst average to the worst level', () => {
+    const scores = [buildScore(ScoreLevel.VeryBad), buildScore(ScoreLevel.VeryBad)]
+
+    expect(getAverageScoreLevel(scores)).toBe(ScoreLevel.VeryBad)
+  })
+})

--- a/clients/assessment_component/src/assessment/pages/utils/getWeightedScoreLevel.test.ts
+++ b/clients/assessment_component/src/assessment/pages/utils/getWeightedScoreLevel.test.ts
@@ -1,0 +1,125 @@
+import { ScoreLevel } from '@tumaet/prompt-shared-state'
+import { describe, expect, it } from 'vitest'
+
+import type { CategoryWithCompetencies } from '../../interfaces/category'
+import type { Competency } from '../../interfaces/competency'
+import type { CompetencyScore } from '../../interfaces/competencyScore'
+import { getWeightedScoreLevel } from './getWeightedScoreLevel'
+
+const buildCompetency = (id: string, weight: number): Competency => ({
+  id,
+  categoryID: 'category-1',
+  name: id,
+  shortName: id,
+  description: '',
+  descriptionVeryBad: '',
+  descriptionBad: '',
+  descriptionOk: '',
+  descriptionGood: '',
+  descriptionVeryGood: '',
+  weight,
+})
+
+const buildCategory = (
+  id: string,
+  weight: number,
+  competencies: Competency[],
+): CategoryWithCompetencies => ({
+  id,
+  name: id,
+  shortName: id,
+  weight,
+  competencies,
+})
+
+const buildScore = (competencyID: string, scoreLevel: ScoreLevel): CompetencyScore => ({
+  id: `score-${competencyID}-${scoreLevel}`,
+  courseParticipationID: 'participation-1',
+  coursePhaseID: 'phase-1',
+  competencyID,
+  scoreLevel,
+})
+
+describe('getWeightedScoreLevel', () => {
+  it('returns 0 without scores or without categories', () => {
+    const category = buildCategory('category-1', 1, [buildCompetency('competency-1', 1)])
+
+    expect(getWeightedScoreLevel([], [category])).toBe(0)
+    expect(getWeightedScoreLevel([buildScore('competency-1', ScoreLevel.Good)], [])).toBe(0)
+  })
+
+  it('maps a single score to its numeric level', () => {
+    const category = buildCategory('category-1', 1, [buildCompetency('competency-1', 1)])
+
+    expect(
+      getWeightedScoreLevel([buildScore('competency-1', ScoreLevel.VeryGood)], [category]),
+    ).toBe(1)
+  })
+
+  it('averages equally weighted competencies', () => {
+    const category = buildCategory('category-1', 1, [
+      buildCompetency('competency-1', 1),
+      buildCompetency('competency-2', 1),
+    ])
+    const scores = [
+      buildScore('competency-1', ScoreLevel.VeryGood),
+      buildScore('competency-2', ScoreLevel.Ok),
+    ]
+
+    expect(getWeightedScoreLevel(scores, [category])).toBe(2)
+  })
+
+  it('weights competencies within a category', () => {
+    const category = buildCategory('category-1', 1, [
+      buildCompetency('competency-1', 3),
+      buildCompetency('competency-2', 1),
+    ])
+    const scores = [
+      buildScore('competency-1', ScoreLevel.VeryGood),
+      buildScore('competency-2', ScoreLevel.VeryBad),
+    ]
+
+    expect(getWeightedScoreLevel(scores, [category])).toBe(2)
+  })
+
+  it('weights categories against each other', () => {
+    const categories = [
+      buildCategory('category-1', 3, [buildCompetency('competency-1', 1)]),
+      buildCategory('category-2', 1, [buildCompetency('competency-2', 1)]),
+    ]
+    const scores = [
+      buildScore('competency-1', ScoreLevel.VeryGood),
+      buildScore('competency-2', ScoreLevel.VeryBad),
+    ]
+
+    expect(getWeightedScoreLevel(scores, categories)).toBe(2)
+  })
+
+  it('ignores the weight of a category that has no score at all', () => {
+    const categories = [
+      buildCategory('category-1', 1, [buildCompetency('competency-1', 1)]),
+      buildCategory('category-2', 9, [buildCompetency('competency-2', 1)]),
+    ]
+
+    expect(getWeightedScoreLevel([buildScore('competency-1', ScoreLevel.Good)], categories)).toBe(2)
+  })
+
+  it('ignores an unscored competency inside a scored category', () => {
+    const category = buildCategory('category-1', 1, [
+      buildCompetency('competency-1', 1),
+      buildCompetency('competency-2', 1),
+    ])
+
+    expect(getWeightedScoreLevel([buildScore('competency-1', ScoreLevel.Bad)], [category])).toBe(4)
+  })
+
+  it('averages several scores for the same competency', () => {
+    const category = buildCategory('category-1', 1, [buildCompetency('competency-1', 1)])
+    const scores = [
+      buildScore('competency-1', ScoreLevel.VeryGood),
+      buildScore('competency-1', ScoreLevel.Ok),
+    ]
+
+    expect(getWeightedScoreLevel(scores, [category])).toBe(2)
+  })
+})

--- a/clients/assessment_component/src/assessment/pages/utils/gradeConfig.test.ts
+++ b/clients/assessment_component/src/assessment/pages/utils/gradeConfig.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { isValidGrade, validateGrade } from './gradeConfig'
+
+describe('validateGrade', () => {
+  it('requires a grade', () => {
+    expect(validateGrade('')).toEqual({ isValid: false, error: 'a grade must be selected' })
+    expect(validateGrade('   ')).toEqual({ isValid: false, error: 'a grade must be selected' })
+  })
+
+  it('rejects a value that is not a number', () => {
+    expect(validateGrade('very good')).toEqual({
+      isValid: false,
+      error: 'Grade must be a valid number',
+    })
+  })
+
+  it('rejects a value outside the German grade range', () => {
+    expect(validateGrade('0.9').error).toBe('Grade must be between 1.0 and 5.0')
+    expect(validateGrade('5.1').error).toBe('Grade must be between 1.0 and 5.0')
+  })
+
+  it('rejects a number inside the range that is not a grade', () => {
+    expect(validateGrade('4.3').error).toMatch(/predefined values/)
+    expect(validateGrade('4.5').error).toMatch(/predefined values/)
+  })
+
+  it('accepts every predefined grade', () => {
+    expect(validateGrade('1.0')).toEqual({ isValid: true, value: 1.0 })
+    expect(validateGrade('1.7')).toEqual({ isValid: true, value: 1.7 })
+    expect(validateGrade('4.0')).toEqual({ isValid: true, value: 4.0 })
+    expect(validateGrade('5.0')).toEqual({ isValid: true, value: 5.0 })
+  })
+
+  it('accepts a grade written without a trailing decimal', () => {
+    expect(validateGrade('2')).toEqual({ isValid: true, value: 2 })
+  })
+})
+
+describe('isValidGrade', () => {
+  it('narrows a number to a grade value', () => {
+    expect(isValidGrade(3.3)).toBe(true)
+    expect(isValidGrade(3.5)).toBe(false)
+  })
+})

--- a/clients/package.json
+++ b/clients/package.json
@@ -24,7 +24,8 @@
     "format": "biome format",
     "format:fix": "biome format --fix",
     "check": "biome check",
-    "check:fix": "biome check --fix"
+    "check:fix": "biome check --fix",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
@@ -106,6 +107,7 @@
     "lerna": "^10.0.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.11",
     "webpack-bundle-analyzer": "^5.3.1"
   },
   "packageManager": "yarn@4.18.0"

--- a/clients/sharedPackageImport.test.ts
+++ b/clients/sharedPackageImport.test.ts
@@ -1,0 +1,8 @@
+import { mapScoreLevelToNumber, ScoreLevel } from '@tumaet/prompt-shared-state'
+import { describe, expect, it } from 'vitest'
+
+describe('shared package imports', () => {
+  it('resolves @tumaet/prompt-shared-state from the package root', () => {
+    expect(mapScoreLevelToNumber(ScoreLevel.VeryGood)).toBe(1)
+  })
+})

--- a/clients/vitest.config.mts
+++ b/clients/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  // @tumaet packages ship sourcemaps whose sources are not published, which Vite warns about per file
+  logLevel: 'error',
+  // Tests never import CSS, and loading the workspace postcss config warns about its module type
+  css: { postcss: {} },
+  test: {
+    environment: 'node',
+    include: ['*.test.ts', '*/src/**/*.test.{ts,tsx}'],
+    setupFiles: ['./vitest.setup.ts'],
+  },
+})

--- a/clients/vitest.setup.ts
+++ b/clients/vitest.setup.ts
@@ -1,0 +1,22 @@
+const TEST_ENV = {
+  ENVIRONMENT: 'development',
+  CORE_HOST: 'http://core.test',
+  INTRO_COURSE_HOST: 'http://intro-course.test',
+  TEAM_ALLOCATION_HOST: 'http://team-allocation.test',
+  ASSESSMENT_HOST: 'http://assessment.test',
+  DEVOPS_CHALLENGE_HOST: 'http://devops-challenge.test',
+  INTERVIEW_HOST: 'http://interview.test',
+  KEYCLOAK_HOST: 'http://keycloak.test',
+  KEYCLOAK_REALM_NAME: 'prompt',
+  CHAIR_NAME_LONG: 'Test Chair',
+  CHAIR_NAME_SHORT: 'Test Chair',
+  GITHUB_SHA: 'test-sha',
+  GITHUB_REF: 'test-ref',
+  SERVER_IMAGE_TAG: 'test-tag',
+  SELF_TEAM_ALLOCATION_HOST: 'http://self-team-allocation.test',
+  TEMPLATE_HOST: 'http://template.test',
+  CERTIFICATE_HOST: 'http://certificate.test',
+  SENTRY_DSN_CLIENT: 'http://sentry.test',
+}
+
+Object.assign(globalThis, { window: { env: TEST_ENV } })

--- a/clients/yarn.lock
+++ b/clients/yarn.lock
@@ -2034,6 +2034,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.147.0":
+  version: 0.147.0
+  resolution: "@oxc-project/types@npm:0.147.0"
+  checksum: 10c0/adec7c1d4c0a031a83afe976884695ff1467987da3f9e775d24bd596ca82346d3734cc9898f5645955050246a13621b4442696753a2d83d2954127fbdfbd5a5f
+  languageName: node
+  linkType: hard
+
 "@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.29
   resolution: "@polka/url@npm:1.0.0-next.29"
@@ -3411,6 +3418,118 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm-eabi@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-android-arm-eabi@npm:1.2.6"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.6"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.6"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.6"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.6"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.6"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.6"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.6"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.6"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.6"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.6"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.6"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.6"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.6"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.6":
+  version: 1.2.6
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.6"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10c0/99d9b06d90196823e4d8c841f258db7a16e5dbba5824a2962b05d907b79f1ba929d56f22dd744fd530936e568c865ee56a719dc31e57e13bc0a8eb4764a8d8dd
+  languageName: node
+  linkType: hard
+
 "@rspack/binding-darwin-arm64@npm:2.1.10":
   version: 2.1.10
   resolution: "@rspack/binding-darwin-arm64@npm:2.1.10"
@@ -3714,7 +3833,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0":
+"@standard-schema/spec@npm:^1.0.0, @standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
@@ -4840,6 +4959,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
+  languageName: node
+  linkType: hard
+
 "@types/d3-array@npm:^3.0.3":
   version: 3.2.2
   resolution: "@types/d3-array@npm:3.2.2"
@@ -4941,6 +5070,20 @@ __metadata:
     "@types/d3-interpolate": "npm:*"
     "@types/d3-selection": "npm:*"
   checksum: 10c0/1dbdbcafddcae12efb5beb6948546963f29599e18bc7f2a91fb69cc617c2299a65354f2d47e282dfb86fec0968406cd4fb7f76ba2d2fb67baa8e8d146eb4a547
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.0":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 
@@ -5064,6 +5207,88 @@ __metadata:
   version: 0.0.6
   resolution: "@types/use-sync-external-store@npm:0.0.6"
   checksum: 10c0/77c045a98f57488201f678b181cccd042279aff3da34540ad242f893acc52b358bd0a8207a321b8ac09adbcef36e3236944390e2df4fcedb556ce7bb2a88f2a8
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:4.1.11":
+  version: 4.1.11
+  resolution: "@vitest/expect@npm:4.1.11"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.11"
+    "@vitest/utils": "npm:4.1.11"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/0aa5e0973aca93a58cbdc3041c6bfed5897e976124965203b96a23b811f4ca403590c7eb15802c8d8366ec27a1db0682451e8a91c4d06617636de262baf86e4b
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.11":
+  version: 4.1.11
+  resolution: "@vitest/mocker@npm:4.1.11"
+  dependencies:
+    "@vitest/spy": "npm:4.1.11"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/3111ea34bd5046f6c70bbd67cf8b89608ee8c41cb27ab2bd61d42f4b68810e9ea16a9a757a71bc254c105f73b407d00ebb6bab1ab0f7f5cdcc9d7d16602a3933
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.11":
+  version: 4.1.11
+  resolution: "@vitest/pretty-format@npm:4.1.11"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/ad32525c73807c0b72f38dc29bc51fd5a17879dc650f37995a9c5adbb8526e15f787691f76aa8768448ec7ed5bf5ba2b12329eac8fda1428b4d6b8c036390f71
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.11":
+  version: 4.1.11
+  resolution: "@vitest/runner@npm:4.1.11"
+  dependencies:
+    "@vitest/utils": "npm:4.1.11"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/3c782b055e9e688e1785f7c8937bd1669bad1b0e5758cb8b844f918f30a324b1d21e174d46c941ce80ebf37f2b89b55b6d619a675025914a1ece6377b95909e2
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.11":
+  version: 4.1.11
+  resolution: "@vitest/snapshot@npm:4.1.11"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.11"
+    "@vitest/utils": "npm:4.1.11"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/35d82a7c2a3e4b57529c30387d568d9106b6bf960189214e5d8cb1f5288cb042305c2e5c7b0b2f8cb56a2c814973de0310bc56d72deb79427bea272b6224190c
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.11":
+  version: 4.1.11
+  resolution: "@vitest/spy@npm:4.1.11"
+  checksum: 10c0/06c68247a8efd21006abe7532fee17f30ba83c8cda3e0b952ef89e278d58058f4b1de69b6bbaa2ed614c568bf4f5769fcc76be42802dedf2bcdd9c0aae601740
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.11":
+  version: 4.1.11
+  resolution: "@vitest/utils@npm:4.1.11"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.11"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/a2c1ddc64333458c3e031465c1ee0440a7660fd1b298c54ccbf865ef1e5cf3ebdd6c5c75a5ea235d8a672498b394e7121f992b096f021f45014ab25e9abd1b52
   languageName: node
   linkType: hard
 
@@ -5285,6 +5510,13 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 10c0/429897e68110374f39b771ec47a7161fc6a8fc33e196857c0a396dc75df0b5f65e4d046674db764330b6bb66b39ef48dd7c53b6a2ee75cfb0681e0c1a7033962
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
   languageName: node
   linkType: hard
 
@@ -5565,6 +5797,13 @@ __metadata:
     "@rspack/core": "npm:^2.1.10"
   languageName: unknown
   linkType: soft
+
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
+  languageName: node
+  linkType: hard
 
 "chalk@npm:4.1.2, chalk@npm:^4.1.0":
   version: 4.1.2
@@ -5924,6 +6163,13 @@ __metadata:
   version: 0.1.0
   resolution: "convert-hex@npm:0.1.0"
   checksum: 10c0/80b5c3f4db67b9fcad6c7539997117c5ee41f8142bc82bddda5da0d699dbed33ab8c1e86a075867468766702330cac4c559930ae371c953e4ae46118f3578d06
+  languageName: node
+  linkType: hard
+
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 10c0/8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
   languageName: node
   linkType: hard
 
@@ -6557,6 +6803,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.0.0":
+  version: 2.3.2
+  resolution: "es-module-lexer@npm:2.3.2"
+  checksum: 10c0/5e7389424c43478439f12f9a6aca1750f6f99afa384fc3de329f4a45f152ab156671055008adaafc74960877abf8cc338aeebf6bed8c21297b146fd6eb7a22f8
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -6620,6 +6873,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "eventemitter3@npm:^4.0.4":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
@@ -6657,6 +6919,13 @@ __metadata:
     signal-exit: "npm:^3.0.3"
     strip-final-newline: "npm:^2.0.0"
   checksum: 10c0/e110add7ca0de63aea415385ebad7236c8de281d5d9a916dbd69f59009dac3d5d631e6252c2ea5d0258220b0d22acf25649b2caf05fa162eaa1401339fc69ba4
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10c0/d40d76b8570695d36587beb3cc28494da2ca3ec8f04e67f5622ed2d372d850e401a9adef19c6835e1a8173903f157c79540b34c7b3fbd7cd8ce726cc903c57b7
   languageName: node
   linkType: hard
 
@@ -6861,7 +7130,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -6871,7 +7140,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -7767,9 +8036,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-android-arm64@npm:1.33.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-darwin-arm64@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-darwin-arm64@npm:1.32.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-arm64@npm:1.33.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -7781,9 +8064,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-darwin-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-x64@npm:1.33.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "lightningcss-freebsd-x64@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-freebsd-x64@npm:1.32.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-freebsd-x64@npm:1.33.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -7795,9 +8092,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm-gnueabihf@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.33.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-arm64-gnu@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.33.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -7809,9 +8120,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-x64-gnu@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.33.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -7823,6 +8148,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-x64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-arm64-msvc@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
@@ -7830,9 +8162,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-win32-arm64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-x64-msvc@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.33.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7877,6 +8223,49 @@ __metadata:
     lightningcss-win32-x64-msvc:
       optional: true
   checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss@npm:1.33.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.33.0"
+    lightningcss-darwin-arm64: "npm:1.33.0"
+    lightningcss-darwin-x64: "npm:1.33.0"
+    lightningcss-freebsd-x64: "npm:1.33.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.33.0"
+    lightningcss-linux-arm64-gnu: "npm:1.33.0"
+    lightningcss-linux-arm64-musl: "npm:1.33.0"
+    lightningcss-linux-x64-gnu: "npm:1.33.0"
+    lightningcss-linux-x64-musl: "npm:1.33.0"
+    lightningcss-win32-arm64-msvc: "npm:1.33.0"
+    lightningcss-win32-x64-msvc: "npm:1.33.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/ce1f8279fbae636dbf37fa6e7385d5f98ed881d72af3362f24afbd4685e19c1fcdfecf17e5dd77f2ebee3d0c23ade276230d85842d07292229a2cffba8ff20a3
   languageName: node
   linkType: hard
 
@@ -8754,6 +9143,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.1":
+  version: 2.1.4
+  resolution: "obug@npm:2.1.4"
+  checksum: 10c0/34a0ee97cd88573cfd97d384c2a79f07118ae5680d7e45d1de6e99c74eddefe145e8ca27a2db02195a1ee5fded5aa22b924869c842728c201b9f109a27d0ef19
+  languageName: node
+  linkType: hard
+
 "once@npm:1.4.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
@@ -9033,6 +9429,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -9051,6 +9454,13 @@ __metadata:
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.5":
+  version: 4.0.7
+  resolution: "picomatch@npm:4.0.7"
+  checksum: 10c0/beb6ae02c43ae44e84883b90830196d9046b1726ead292adcf7f57945e0bb0d992d68563d87e03b484b6f3c9a5c6defda7523477f047d7f0e663f126cc01787f
   languageName: node
   linkType: hard
 
@@ -9696,6 +10106,7 @@ __metadata:
     ts-node-register: "npm:^1.0.0"
     typescript: "npm:^6.0.3"
     use-debounce: "npm:^10.1.1"
+    vitest: "npm:^4.1.11"
     webpack-bundle-analyzer: "npm:^5.3.1"
     zod: "npm:^4.4.3"
     zustand: "npm:^5.0.15"
@@ -10326,6 +10737,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:~1.2.4":
+  version: 1.2.6
+  resolution: "rolldown@npm:1.2.6"
+  dependencies:
+    "@oxc-project/types": "npm:=0.147.0"
+    "@rolldown/binding-android-arm-eabi": "npm:1.2.6"
+    "@rolldown/binding-android-arm64": "npm:1.2.6"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.6"
+    "@rolldown/binding-darwin-x64": "npm:1.2.6"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.6"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.6"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.6"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.6"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.6"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.6"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.6"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.6"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.6"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.6"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.6"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm-eabi":
+      optional: true
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/34f8fd335f3ec8e55002aa4f2f6f0ffd4dc1f2c47f877d4ad37fbe62c97d3b63486705494e739b9e451cccf4c4bc4e0f14648d7f978427964c693c0165289308
+  languageName: node
+  linkType: hard
+
 "rope-sequence@npm:^1.3.0":
   version: 1.3.4
   resolution: "rope-sequence@npm:1.3.4"
@@ -10520,6 +10989,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:3.0.7, signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -10701,6 +11177,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.2.0
+  resolution: "std-env@npm:4.2.0"
+  checksum: 10c0/40ac525ce7b7c556abc332a7376f14356eeb1a7f17f6ff9a003eb9f52326ff1f3745d3e1b43452675b1ec6fcc319f1b1d6f3b0d386cf3f91058479ad883cff69
+  languageName: node
+  linkType: hard
+
 "string-width@npm:4.2.3, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -10841,6 +11331,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2":
+  version: 1.3.0
+  resolution: "tinyexec@npm:1.3.0"
+  checksum: 10c0/e9b89f97489d2aab2cef408da279e6b32547e738d1275032ccb8fd0028a006d93eb70fc51c6cffd9fc2f5aca6c2a273d8b6f73b52d46ee5116da6b94969ef958
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:0.2.12":
   version: 0.2.12
   resolution: "tinyglobby@npm:0.2.12"
@@ -10858,6 +11362,23 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
   checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "tinyrainbow@npm:3.1.1"
+  checksum: 10c0/f9d2743832c6191f753408f36224fe817620b8abcef572b2e570204c673a901d753ff84ca8e7b88f9c79e934295b3ffc6fcbc56a06f126e24e1ec6186dcad40d
   languageName: node
   linkType: hard
 
@@ -11207,6 +11728,131 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.2.2
+  resolution: "vite@npm:8.2.2"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.33.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.26"
+    rolldown: "npm:~1.2.4"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.4.0 || ^0.5.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/94cbbbdc38ad500dcb86b6202ddd14aa41d05c80739766cada9bbe250b410d1a27be433c9c491ed39744019471ac1e27a59908616a88c42f9787bdb6bdca49d2
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^4.1.11":
+  version: 4.1.11
+  resolution: "vitest@npm:4.1.11"
+  dependencies:
+    "@vitest/expect": "npm:4.1.11"
+    "@vitest/mocker": "npm:4.1.11"
+    "@vitest/pretty-format": "npm:4.1.11"
+    "@vitest/runner": "npm:4.1.11"
+    "@vitest/snapshot": "npm:4.1.11"
+    "@vitest/spy": "npm:4.1.11"
+    "@vitest/utils": "npm:4.1.11"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.11
+    "@vitest/browser-preview": 4.1.11
+    "@vitest/browser-webdriverio": 4.1.11
+    "@vitest/coverage-istanbul": 4.1.11
+    "@vitest/coverage-v8": 4.1.11
+    "@vitest/ui": 4.1.11
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: ./vitest.mjs
+  checksum: 10c0/3fa0948cf74adcccc8cbcdb4e6d30ada6933bdfb1816ff99200f3d3b689325b37dc483b22535b57b6d911f7a7b64eaa6a5f8da1606cfe7f2466f48000c21e296
+  languageName: node
+  linkType: hard
+
 "w3c-keyname@npm:^2.2.0":
   version: 2.2.8
   resolution: "w3c-keyname@npm:2.2.8"
@@ -11291,6 +11937,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

No workspace in `clients/` had a test runner, so 60,884 lines of TypeScript could only be exercised
through the Playwright suite and its Docker stack. This adds Vitest at the `clients/` root and seeds
it with the modules whose interfaces were already in the right shape.

## Details

**Runner**

- `clients/vitest.config.mts` — one config for all nine workspaces, `node` environment, tests
  discovered as `*/src/**/*.test.{ts,tsx}`.
- `clients/vitest.setup.ts` — supplies the `window.env` values `@tumaet/prompt-shared-state` reads at
  import time, so the shared package resolves its hosts deterministically instead of warning about
  missing keys on every run.
- `clients/sharedPackageImport.test.ts` — guards that the shared package still loads from its root.
  Its published ESM uses extensionless directory imports, so this is the part of the setup most
  likely to break silently.
- `yarn test` in `clients/`, `make test-clients`, and a `test-client` job in `quality-clients.yml`.
  `make test` now runs the client tests before the server suites. A single workspace is
  `yarn vitest run <workspace>`.
- No per-workspace `test` script: a root config plus a positional filter gives the same targeting
  without touching nine `package.json` files.

**Tests** — 51 across 7 files, no production code touched:

| Module | What is pinned |
| --- | --- |
| `fillCampusGrades` | registration numbers padded on one side only, the case- and diacritic-insensitive name fallback, keys resolving to two students reported as ambiguous and left untouched, short rows grown before the write, replaced grades reported rather than silently overwritten, graded students no row consumed |
| `campusCsvEncoding` | Windows-1252 and UTF-8-with-BOM round trips, the 27 printable characters Windows-1252 keeps in the C1 range, unmappable characters written as `?`, UTF-16 rejected instead of corrupted |
| `getWeightedScoreLevel` | competency and category weighting, a category with no score dropping out of the denominator while an unscored competency inside a scored category does not, several scores for one competency averaged first |
| `getAverageScoreLevel` | the level boundaries |
| `validateGrade` / `isValidGrade` | the German grade range, and values inside it that are not grades |
| `computeQuartile` | sorting, interpolation between neighbours, the extremes, and that the input is not mutated |

Two configuration notes worth knowing for the next person:

- `logLevel: 'error'` is set because the shared packages ship sourcemaps whose sources are not
  published, which Vite otherwise warns about once per file (about 40 lines per run).
- `css: { postcss: {} }` stops Vite loading `clients/postcss.config.js`, which is ESM in a package
  without `"type": "module"` and triggers a Node re-parse warning. Tests never import CSS.

Vitest 4 processes `node_modules` dependencies through Vite by default, so no
`server.deps.inline` entry is needed for the `@tumaet` packages. The smoke test is what will catch
it if that ever changes.

## Reason / Link to issue

Closes #2090.

Prerequisite for #2097 and #2101: refactoring 17,603 lines that no test can observe is the expensive
order to work in.

## How to Test

```bash
make test-clients                                  # 51 tests, about 2s, no Docker
cd clients && yarn vitest run assessment_component # one workspace
cd clients && yarn tsc -p assessment_component/tsconfig.json --noEmit --pretty false
cd clients && yarn biome check .
```

## PR Checklist

- [x] Tested locally or on the dev environment
- [x] Code is clean, readable, and documented
- [x] Tests added or updated (if needed)
- [ ] Screenshots attached for UI changes (if any)
- [x] Documentation updated (if relevant)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive client-side unit tests for grade validation, score calculations, quartiles, CSV encoding, grade imports, and shared package exports.
  * Expanded coverage for edge cases, invalid inputs, data preservation, and weighting behavior.

* **Build & Quality**
  * Added a dedicated client test command and integrated it into the full test workflow.
  * Added automated client test execution to quality checks.

* **Documentation**
  * Updated testing guidance with client test commands, conventions, and tool recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->